### PR TITLE
Add `threshold` parameter to `xref` cli command

### DIFF
--- a/nomenklatura/cli.py
+++ b/nomenklatura/cli.py
@@ -26,10 +26,12 @@ def _get_resolver(file_path: Path, resolver_path: Optional[Path]) -> Resolver[En
     return Resolver[Entity].load(Path(path))
 
 
-def index_xref(loader: FileLoader, resolver: Resolver[Entity]) -> None:
+def index_xref(
+    loader: FileLoader, resolver: Resolver[Entity], threshold: Optional[int] = None
+) -> None:
     index = Index(loader)
     index.build()
-    xref(index, resolver, loader)
+    xref(index, resolver, loader, threshold=threshold)
 
 
 @click.group(help="Nomenklatura data integration")
@@ -50,10 +52,13 @@ def index(path: Path, index: Optional[Path] = None) -> None:
 @cli.command("xref", help="Generate dedupe candidates")
 @click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
 @click.option("-r", "--resolver", type=click.Path(writable=True, path_type=Path))
-def xref_file(path: Path, resolver: Optional[Path] = None) -> None:
+@click.option("-t", "--threshold", type=click.INT)
+def xref_file(
+    path: Path, resolver: Optional[Path] = None, threshold: Optional[int] = None
+) -> None:
     resolver_ = _get_resolver(path, resolver)
     loader = FileLoader(path, resolver=resolver_)
-    index_xref(loader, resolver_)
+    index_xref(loader, resolver_, threshold)
     resolver_.save()
     log.info("Xref complete in: %s", resolver_.path)
 

--- a/nomenklatura/resolver.py
+++ b/nomenklatura/resolver.py
@@ -273,7 +273,7 @@ class Resolver(Generic[E]):
     ) -> Identifier:
         edge = self.get_edge(left_id, right_id)
         if edge is None:
-            edge = Edge(left_id, right_id)
+            edge = Edge(left_id, right_id, judgement=judgement)
 
         # Canonicalise positive matches, i.e. make both identifiers refer to a
         # canonical identifier, instead of making a direct link.


### PR DESCRIPTION
The only option to deduplicate Follow the Money entities is to make
decisions manually via `dedupe` command. This change adds a new `threshold`
parameter to the `xref` command to allow user set a threshold and have
FTM entities marked either "positive" or "negative" in file with
de-duplication data.