### PR TITLE
Fix xref stats reporting for zero index pairs

### DIFF
--- a/nomenklatura/xref.py
+++ b/nomenklatura/xref.py
@@ -43,6 +43,7 @@ def xref(
     try:
         scores: List[float] = []
         suggested = 0
+        idx = 0
         for idx, ((left_id, right_id), score) in enumerate(index.pairs()):
             if idx % 1000 == 0 and idx > 0:
                 _print_stats(idx, suggested, scores)


### PR DESCRIPTION
the statement in line 92 fails if there where no index pairs, so lets have a default idx = 0