### PR TITLE
FileLoader: only add dataset from file stem if proxy has no datasets

### DIFF
--- a/nomenklatura/loader.py
+++ b/nomenklatura/loader.py
@@ -1,23 +1,15 @@
 import json
 import logging
 from pathlib import Path
-from typing import (
-    Dict,
-    Generator,
-    Generic,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Tuple,
-)
-from followthemoney.types import registry
-from followthemoney.property import Property
-from followthemoney import model
+from typing import Dict, Generator, Generic, Iterable, Iterator, List, Optional, Tuple
 
+from followthemoney import model
+from followthemoney.property import Property
+from followthemoney.types import registry
+
+from nomenklatura.dataset import DS, Dataset
+from nomenklatura.entity import CE, CompositeEntity
 from nomenklatura.resolver import Resolver
-from nomenklatura.dataset import Dataset, DS
-from nomenklatura.entity import CompositeEntity, CE
 
 log = logging.getLogger(__name__)
 
@@ -124,7 +116,8 @@ class FileLoader(MemoryLoader[Dataset, CompositeEntity]):
                     break
                 data = json.loads(line)
                 proxy = CompositeEntity.from_dict(model, data)
-                proxy.datasets.add(dataset.name)
+                if not proxy.datasets:
+                    proxy.datasets.add(dataset.name)
                 yield proxy
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Assign a dataset to an entity based on the filename stem only if this entity doesn't have any datasets.

Otherwise, assigning the filename stem based dataset to all entities will blow up the dedupe scoring for different datasets (it will always be <0.7 as all entities share at least the filename stem dataset name)

the other changes in this commit are just isort/black/flake8 adjustments by my editor, sorry.