### PR TITLE
Place all wikidata labels under name property

### DIFF
--- a/nomenklatura/enrich/wikidata/__init__.py
+++ b/nomenklatura/enrich/wikidata/__init__.py
@@ -241,13 +241,14 @@ class WikidataEnricher(Enricher):
             return None
         proxy.add("modifiedAt", item.modified)
         proxy.add("wikidataId", item.id)
-        item.label.apply(proxy, "name")
+        for label in item.labels:
+            label.apply(proxy, "name")
         item.description.apply(proxy, "notes")
         for alias in item.aliases:
             alias.apply(proxy, "alias")
 
         if proxy.schema.is_a("Person") and not item.is_instance("Q5"):
-            log.debug("Person is not a Q5 [%s]: %s", item.id, item.label)
+            log.debug("Person is not a Q5 [%s]: %s", item.id, item.labels)
             return None
 
         for claim in item.claims:

--- a/nomenklatura/enrich/wikidata/model.py
+++ b/nomenklatura/enrich/wikidata/model.py
@@ -68,17 +68,15 @@ class Item(object):
         self.modified: Optional[str] = data.pop("modified", None)
 
         labels: Dict[str, Dict[str, str]] = data.pop("labels", {})
-        self.label: LangText = pick_obj_lang(labels)
-        self.aliases: Set[LangText] = set()
+        self.labels: Set[LangText] = set()
         for obj in labels.values():
-            self.aliases.add(LangText(obj["value"], obj["language"]))
+            self.labels.add(LangText(obj["value"], obj["language"]))
 
         aliases: Dict[str, List[Dict[str, str]]] = data.pop("aliases", {})
+        self.aliases: Set[LangText] = set()
         for lang in aliases.values():
             for obj in lang:
                 self.aliases.add(LangText(obj["value"], obj["language"]))
-
-        self.aliases.discard(self.label)
 
         descriptions: Dict[str, Dict[str, str]] = data.pop("descriptions", {})
         self.description = pick_obj_lang(descriptions)


### PR DESCRIPTION
This has the fun outcome that the lang of name statements isn't necessarily one of the chosen few any more. Because many languages can have the same value, and be processed before the previously-preferred languages.