### PR TITLE
Add introduced field to dataset coverage

### DIFF
--- a/nomenklatura/dataset/coverage.py
+++ b/nomenklatura/dataset/coverage.py
@@ -19,6 +19,7 @@ class DataCoverage(object):
     )
 
     def __init__(self, data: Dict[str, Any]) -> None:
+        self.introduced = type_check(registry.date, data.get("introduced"))
         self.start = type_check(registry.date, data.get("start"))
         self.end = type_check(registry.date, data.get("end"))
         self.countries: List[str] = []
@@ -30,6 +31,7 @@ class DataCoverage(object):
 
     def to_dict(self) -> Dict[str, Any]:
         data = {
+            "introduced": self.introduced,
             "start": self.start,
             "end": self.end,
             "countries": self.countries,

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -38,6 +38,7 @@ def test_company_dataset(catalog_data: Dict[str, Any]):
     assert "coverage" in ds.to_dict()
     assert ds.coverage.start == "2005"
     assert ds.coverage.end == "2010-01"
+    assert ds.coverage.introduced == "2024-02-20"
     assert "us" in ds.coverage.countries
 
     assert "company_data" in repr(ds)

--- a/tests/fixtures/catalog.yml
+++ b/tests/fixtures/catalog.yml
@@ -22,6 +22,7 @@ datasets:
       country: us
       logo_url: https://placekitten.com/400/400
     coverage:
+      introduced: 2024-02-20
       start: 2005
       end: 2010-01
       frequency: monthly


### PR DESCRIPTION
In opensanctions/crawler-planning#76 we'd like to represent the date a dataset was first created in its metadata.

Temporal coverage tends to speak to the contents of the dataset.

Our datasets are normally point in time snapshots rather than time series covering the period since when the dataset was introduced. `coverage.end` is used well to indicate that the contents will not cover data later than that date. `coverage.start` would make sense to indicate e.g. the start of historical data in our dataset, e.g. if a source includes PEP position occupancy starting in 2004, or the age of the oldest sanction in the dataset.

I'd prefer not using `coverage.start` to represent the introduction of the dataset, because users might believe that we include historical data when we don't. Some datasets are also based on snapshots earlier than the date the data was added to opensanctions.

To avoid confusion with the date a particular release was created, I think `coverage.introduced` works well to describe what we're saying, rather than `coverage.created`.