### PR TITLE
Warn of potential conflicting merges

### DIFF
--- a/nomenklatura/conflicting_match.py
+++ b/nomenklatura/conflicting_match.py
@@ -64,10 +64,16 @@ class ConflictingMatchReporter(Generic[CE]):
         self.console.print(table)
 
     def report(self) -> None:
+        conflicts = list(self.get_conflicting_matches())
+        if not conflicts:
+            return
+
+        self.console.print("[bold]Potential conflicting matches found:\n[/bold]")
         for candidate_id, left_id, right_id in self.get_conflicting_matches():
             left = self.view.get_entity(left_id)
             right = self.view.get_entity(right_id)
             candidate = self.view.get_entity(candidate_id)
+
             if candidate:
                 self.report_conflicting_match("Candidate", candidate)
             if left:

--- a/nomenklatura/conflicting_match.py
+++ b/nomenklatura/conflicting_match.py
@@ -1,0 +1,76 @@
+from typing import Dict, Set, Tuple, Generic, Generator
+from itertools import combinations
+from collections import defaultdict
+from rich.console import Console
+from rich.table import Table
+from rich import box
+
+from nomenklatura.dataset import DS
+from nomenklatura.entity import CE
+from nomenklatura.store import View
+from nomenklatura.judgement import Judgement
+from nomenklatura.resolver import Resolver
+from nomenklatura.statement.statement import Statement
+
+
+class ConflictingMatchReporter(Generic[CE]):
+    def __init__(self, view: View[DS, CE], resolver: Resolver[CE], threshold: float):
+        self.console = Console()
+        self.view = view
+        self.resolver = resolver
+        self.threshold = threshold
+        self.matches: Dict[str, Set[str]] = defaultdict(set)
+
+    def check_match(self, score: float, left_id: str, right_id: str) -> None:
+        if score > self.threshold:
+            self.matches[left_id].add(right_id)
+            self.matches[right_id].add(left_id)
+
+    def get_conflicting_matches(self) -> Generator[Tuple[str, str, str], None, None]:
+        for candidate_id, matches in self.matches.items():
+            for left_id, right_id in combinations(matches, 2):
+                judgement = self.resolver.get_judgement(left_id, right_id)
+                if judgement == Judgement.NEGATIVE:
+                    yield candidate_id, left_id, right_id
+
+    @staticmethod
+    def _sort_key(stmt: Statement) -> Tuple[str, str, int, str, int]:
+        prop_order = 0 if stmt.prop == "name" else 1
+        lang_order = 0 if stmt.lang is None else 1
+        return (stmt.dataset, stmt.entity_id, prop_order, stmt.value, lang_order)
+
+    def report_conflicting_match(self, title: str, entity: CE) -> None:
+        if entity.id is None:
+            return
+        statements = []
+        for stmt in entity.statements:
+            if stmt.prop in {"name", "alias"}:
+                statements.append(stmt)
+
+        table = Table(box=box.SIMPLE, expand=True)
+        table.add_column("Dataset", style="cyan", max_width=20)
+        table.add_column("Entity ID", style="magenta", max_width=30)
+        table.add_column("Prop", style="blue")
+        table.add_column("Lang", style="green")
+        table.add_column("Name", style="yellow")
+
+        for stmt in sorted(statements, key=self._sort_key):
+            table.add_row(
+                stmt.dataset, stmt.entity_id, stmt.prop, stmt.lang, "• " + stmt.value
+            )
+
+        self.console.print(f"[bold]{title}[/bold]:")
+        self.console.print(f"{entity.id}")
+        self.console.print(table)
+
+    def report(self) -> None:
+        for candidate_id, left_id, right_id in self.get_conflicting_matches():
+            left = self.view.get_entity(left_id)
+            right = self.view.get_entity(right_id)
+            candidate = self.view.get_entity(candidate_id)
+            if candidate:
+                self.report_conflicting_match("Candidate", candidate)
+            if left:
+                self.report_conflicting_match("Left side of negative decision", left)
+            if right:
+                self.report_conflicting_match("Right side of negative decision", right)

--- a/tests/test_xref.py
+++ b/tests/test_xref.py
@@ -1,4 +1,6 @@
 import logging
+
+from normality import collapse_spaces
 from nomenklatura.dataset.dataset import Dataset
 from nomenklatura.judgement import Judgement
 from nomenklatura.matching.regression_v1.model import RegressionV1
@@ -80,6 +82,13 @@ def test_xref_potential_conflicts(
         algorithm=RegressionV1,
         conflicting_match_threshold=0.9,
     )
-    logs = {r.message for r in caplog.records}
+    stdout = capsys.readouterr().out
 
-    assert "Potential conflict: b <> a for c" in logs
+    assert "Potential conflicting matches found:" in stdout, stdout
+    assert "Candidate:\nc\n" in stdout, stdout
+    assert "Left side of negative decision:\nb\n" in stdout, stdout
+    assert "Right side of negative decision:\na\n" in stdout, stdout
+    flat = collapse_spaces(stdout)
+    assert a.get("name")[0] in flat, flat
+    assert b.get("name")[0] in flat, flat
+    assert c.get("name")[0] in flat, flat

--- a/tests/test_xref.py
+++ b/tests/test_xref.py
@@ -1,3 +1,8 @@
+import logging
+from nomenklatura.dataset.dataset import Dataset
+from nomenklatura.judgement import Judgement
+from nomenklatura.matching.regression_v1.model import RegressionV1
+from nomenklatura.store.memory import MemoryStore
 from nomenklatura.xref import xref
 from nomenklatura.store import SimpleMemoryStore
 from nomenklatura.resolver import Resolver
@@ -20,3 +25,65 @@ def test_xref_candidates(
         if left.caption == "Johanna Quandt":
             assert right.caption == "Frau Johanna Quandt"
         assert score > 0.0
+
+
+def test_xref_potential_conflicts(
+    test_dataset: Dataset,
+    caplog,
+):
+    resolver = Resolver[CompositeEntity]()
+    store = MemoryStore(test_dataset, resolver)
+    algorithm = RegressionV1()
+    a = CompositeEntity.from_data(
+        test_dataset,
+        {
+            "id": "a",
+            "schema": "Company",
+            "properties": {
+                "name": "The AAA Weapons and Munitions Factory Joint Stock Company",
+                "address": "Moscow",
+            },
+        },
+    )
+    b = CompositeEntity.from_data(
+        test_dataset,
+        {
+            "id": "b",
+            "schema": "Company",
+            "properties": {
+                "name": "The BBB Weapons and Munitions Factory Joint Stock Company",
+                "address": "Moscow",
+            },
+        },
+    )
+    c = CompositeEntity.from_data(
+        test_dataset,
+        {
+            "id": "c",
+            "schema": "Company",
+            "properties": {
+                "name": "The AAA Weapons and Ammunition Factory Joint Stock Company",
+                "address": "Moscow",
+            },
+        },
+    )
+    writer = store.writer()
+    writer.add_entity(a)
+    writer.add_entity(b)
+    writer.add_entity(c)
+    writer.flush()
+
+    resolver.decide("a", "b", Judgement.NEGATIVE, user="test")
+
+    with caplog.at_level(logging.INFO):
+        xref(
+            resolver,
+            store,
+            # Not the default, but easily gets the scores where this is a problem
+            algorithm=RegressionV1,
+            # Lower than usual just because we're testing with one dataset
+            negative_check_threshold=0.6
+        )
+    logs = {r.message for r in caplog.records}
+
+    assert "Potential conflict: b <> a for c" in logs

--- a/tests/test_xref.py
+++ b/tests/test_xref.py
@@ -1,4 +1,4 @@
-import logging
+import re
 
 from normality import collapse_spaces
 from nomenklatura.dataset.dataset import Dataset
@@ -86,9 +86,9 @@ def test_xref_potential_conflicts(
 
     assert "Potential conflicting matches found:" in stdout, stdout
     assert "Candidate:\nc\n" in stdout, stdout
-    assert "Left side of negative decision:\nb\n" in stdout, stdout
-    assert "Right side of negative decision:\na\n" in stdout, stdout
     flat = collapse_spaces(stdout)
-    assert a.get("name")[0] in flat, flat
-    assert b.get("name")[0] in flat, flat
-    assert c.get("name")[0] in flat, flat
+    assert re.search(r"Left side of negative decision: (b|a)", flat), stdout
+    assert re.search(r"Right side of negative decision: (b|a)", flat), stdout
+    assert a.get("name")[0] in flat, stdout
+    assert b.get("name")[0] in flat, stdout
+    assert c.get("name")[0] in flat, stdout


### PR DESCRIPTION
When A and B have been indicated to be a negative match, sometimes an entity C is merged to A when it really should be merged with B.

Later, another entity D similar to C will score really highly with both A due to its name similarity with C (which is now part of A) when it should only have scored highly with B.

We can detect that C and A were merged incorrectly by seeing if there are two entities A nd B, both with a high score compared with C. If A and B have a negative decision between them, we'll show an alert with the details of the three entities.

This goes away once C has a judgement between one of A and B.

This check is only enabled if conflicting_match_threshold is provided, e.g. via `-m` or `--conflicting-match-threshold` in zavod cli.

![2024-06-13_15-03](https://github.com/opensanctions/nomenklatura/assets/235801/fe2e09a0-a206-47c0-bc0a-65cfd8cd5b29)
