### PR TITLE
Don't score each occurrence of a word in all names cumulatively

### DIFF
--- a/nomenklatura/index/tantivy_index.py
+++ b/nomenklatura/index/tantivy_index.py
@@ -153,11 +153,11 @@ class TantivyIndex(BaseIndex[DS, CE]):
 
         # Any of set of tokens in all values of type
         if field in {registry.address.name, registry.name.name, registry.text.name}:
-            words: Set[str] = set()
+            word_set: Set[str] = set()
             for value in values:
-                words.update(value.split(WS))
-            term_queries: Query = []
-            for word in words:
+                word_set.update(value.split(WS))
+            term_queries: List[Query] = []
+            for word in word_set:
                 term_queries.append(Query.term_query(self.schema, field, word))
             yield Query.boost_query(
                 Query.boolean_query([(Occur.Should, q) for q in term_queries]),

--- a/nomenklatura/index/tantivy_index.py
+++ b/nomenklatura/index/tantivy_index.py
@@ -145,7 +145,7 @@ class TantivyIndex(BaseIndex[DS, CE]):
                 words = value.split(WS)
                 word_count = len(words)
                 if word_count > 1:
-                    slop = 2 * math.ceil(math.log(word_count))
+                    slop = math.ceil(2 * math.log(word_count))
                     yield Query.boost_query(
                         Query.phrase_query(self.schema, field, words, slop),  # type: ignore
                         BOOST_NAME_PHRASE,

--- a/nomenklatura/index/tantivy_index.py
+++ b/nomenklatura/index/tantivy_index.py
@@ -151,7 +151,7 @@ class TantivyIndex(BaseIndex[DS, CE]):
                         BOOST_NAME_PHRASE,
                     )
 
-        # Any of set of tokens in all values of type
+        # Any of set of tokens in all values of the field
         if field in {registry.address.name, registry.name.name, registry.text.name}:
             word_set: Set[str] = set()
             for value in values:

--- a/nomenklatura/index/tantivy_index.py
+++ b/nomenklatura/index/tantivy_index.py
@@ -38,11 +38,11 @@ FULL_TEXT = {
 }
 BOOST_NAME_PHRASE = 4.0
 BOOSTS = {
-    registry.name.name: 2.0,
+    registry.name.name: 1.0,
     registry.phone.name: 3.0,
     registry.email.name: 3.0,
     registry.address.name: 2.5,
-    registry.identifier.name: 4.0,
+    registry.identifier.name: 15.0,
 }
 
 
@@ -128,11 +128,13 @@ class TantivyIndex(BaseIndex[DS, CE]):
         if field == registry.name.name:
             if word_count >= 2:
                 slop = 2 * math.ceil(math.log(word_count))
+                factor = 1 + (word_count / 4)
+                name_phrase_boost = BOOST_NAME_PHRASE * factor
                 # Argument 3 to "phrase_query" of "Query" has incompatible
                 # type "list[str]"; expected "list[str | tuple[int, str]]"
                 yield Query.boost_query(
                     Query.phrase_query(self.schema, field, words, slop),  # type: ignore
-                    BOOST_NAME_PHRASE,
+                    name_phrase_boost,
                 )
 
         if field in {registry.address.name, registry.name.name, registry.text.name}:

--- a/nomenklatura/index/tantivy_index.py
+++ b/nomenklatura/index/tantivy_index.py
@@ -5,6 +5,7 @@ from rigour.ids import StrictFormat
 from followthemoney.types import registry
 from typing import Any, Dict, List, Tuple, Generator
 from tantivy import Query, Occur, Index, SchemaBuilder, Document
+import math
 
 from nomenklatura.dataset import DS
 from nomenklatura.entity import CE
@@ -37,7 +38,7 @@ FULL_TEXT = {
 }
 BOOST_NAME_PHRASE = 4.0
 BOOSTS = {
-    registry.name.name: 1.0,
+    registry.name.name: 2.0,
     registry.phone.name: 3.0,
     registry.email.name: 3.0,
     registry.address.name: 2.5,
@@ -121,9 +122,10 @@ class TantivyIndex(BaseIndex[DS, CE]):
 
     def field_queries(self, field: str, value: str) -> Generator[Query, None, None]:
         words = value.split(WS)
+        word_count = len(words)
         if field == registry.name.name:
-            if len(words) > 2:
-                slop = 1
+            if word_count >= 2:
+                slop = 2 * math.ceil(math.log(word_count))
                 # Argument 3 to "phrase_query" of "Query" has incompatible
                 # type "list[str]"; expected "list[str | tuple[int, str]]"
                 yield Query.boost_query(

--- a/nomenklatura/index/tantivy_index.py
+++ b/nomenklatura/index/tantivy_index.py
@@ -152,7 +152,12 @@ class TantivyIndex(BaseIndex[DS, CE]):
                     )
 
         # Any of set of tokens in all values of the field
-        if field in {registry.address.name, registry.name.name, registry.text.name}:
+        if field in {
+            registry.address.name,
+            registry.name.name,
+            registry.text.name,
+            registry.string.name,
+        }:
             word_set: Set[str] = set()
             for value in values:
                 word_set.update(value.split(WS))

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -1,3 +1,4 @@
+import logging
 import getpass
 from pathlib import Path
 from datetime import datetime
@@ -12,6 +13,8 @@ from nomenklatura.resolver.identifier import Identifier, StrIdent, Pair
 from nomenklatura.resolver.edge import Edge
 from nomenklatura.resolver.linker import Linker
 from nomenklatura.util import PathLike
+
+log = logging.getLogger(__name__)
 
 
 class Resolver(Linker[CE]):
@@ -292,6 +295,7 @@ class Resolver(Linker[CE]):
             cluster.add(edge.target)
             for node in cluster:
                 clusters[node] = cluster
+        log.info("Loaded %s clusters from: %s", len(clusters), path.as_posix())
         return Linker(clusters)
 
     def __repr__(self) -> str:

--- a/tests/index/test_tantivy_index.py
+++ b/tests/index/test_tantivy_index.py
@@ -56,9 +56,9 @@ def test_match_score(dstore: SimpleMemoryStore, tantivy_index: TantivyIndex):
     assert top_result[0] == Identifier(VERBAND_BADEN_ID), top_result
 
     # Terms and phrase match
-    assert 200 < top_result[1] < 1000, matches
+    assert 100 < top_result[1] < 200, matches
     # Terms but not phrase match
-    assert 50 < matches[1][1] < 500, matches
+    assert 40 < matches[1][1] < 100, matches
     # lowest > threshold
     assert matches[-1][1] > 1, matches
 
@@ -93,20 +93,27 @@ def test_index_pairs(dstore: SimpleMemoryStore, tantivy_index: TantivyIndex):
     assert "Company" in schemata
     assert "Address" in schemata
 
+
+    for ((a, b), score) in pairs[:20]:
+        a_e = view.get_entity(a.id)
+        b_e = view.get_entity(b.id)
+        print(f"Score: {score:.2f}\n{a.id}: {a_e.get("name") or a_e.caption}\n{b.id}: {b_e.get('name') or b_e.caption}\n")
+
     top_5 = {p[0] for p in pairs[:5]}
-    assert (
-        Identifier("72fd7df14e87678c9c6dcebb3ef045d11343d64c"),
-        Identifier("152da487401ef4547baf2d2bc95f884dc5f8bba0"),
-    ) in top_5, top_5
     assert (
         Identifier("21cc81bf3b960d2847b66c6c862e7aa9b5e4f487"),
         Identifier("12570ee94b8dc23bcc080e887539d3742b2a5237"),
     ) in top_5, top_5
 
     top_10 = {p[0] for p in pairs[:10]}
+
+    assert (
+        Identifier("72fd7df14e87678c9c6dcebb3ef045d11343d64c"),
+        Identifier("152da487401ef4547baf2d2bc95f884dc5f8bba0"),
+    ) in top_10, top_10
     verband_baden = (
         Identifier("cf9133952825afac1e654542a70ae7ed20dbfa7a"),
-        Identifier("69401823a9f0a97cfdc37afa7c3158374e007669"),
+        Identifier(VERBAND_BADEN_ID),
     )
     assert verband_baden in top_10, top_10
     assert verband_baden not in top_5, top_5

--- a/tests/index/test_tantivy_index.py
+++ b/tests/index/test_tantivy_index.py
@@ -49,9 +49,6 @@ def test_match_score(dstore: SimpleMemoryStore, tantivy_index: TantivyIndex):
     entity = CompositeEntity.from_data(dx, VERBAND_BADEN_DATA)
     matches = tantivy_index.match(entity)
     view = dstore.default_view()
-    for ident, score in matches:
-        match = view.get_entity(ident.id)
-        print(f"Score: {score:.2f}\n{ident.id}: {match.caption}\n{match.to_dict()}\n")
 
     assert len(matches) == 9, matches
 
@@ -96,28 +93,21 @@ def test_index_pairs(dstore: SimpleMemoryStore, tantivy_index: TantivyIndex):
     assert "Company" in schemata
     assert "Address" in schemata
 
-    for rank, ((a, b), score) in enumerate(pairs[:40]):
-        a_e = view.get_entity(a.id)
-        b_e = view.get_entity(b.id)
-        print(
-            f"Rank: {rank} Score: {score:.2f}\n{a.id}: {a_e.get("name") or a_e.caption}\n{b.id}: {b_e.get('name') or b_e.caption}\n"
-        )
-
     top_5 = {p[0] for p in pairs[:5]}
 
     # These score higher than VME, despite having 3 and 4 matching tokens
     # similarly to VME, because their matching tokens are rarer in the corpus
     # than VME's.
 
-    # Bayerische Motorenwerke (BMW) AG
-    assert (
-        Identifier("21cc81bf3b960d2847b66c6c862e7aa9b5e4f487"),
-        Identifier("12570ee94b8dc23bcc080e887539d3742b2a5237"),
-    ) in top_5, top_5
     # Herr Prof. Dr. Schnabel
     assert (
         Identifier("72fd7df14e87678c9c6dcebb3ef045d11343d64c"),
         Identifier("152da487401ef4547baf2d2bc95f884dc5f8bba0"),
+    ) in top_5, top_5
+    # Bayerische Motorenwerke (BMW) AG
+    assert (
+        Identifier("21cc81bf3b960d2847b66c6c862e7aa9b5e4f487"),
+        Identifier("12570ee94b8dc23bcc080e887539d3742b2a5237"),
     ) in top_5, top_5
 
     top_20 = {p[0] for p in pairs[:20]}


### PR DESCRIPTION
## problem 

We couldn't match all current matches with positive decisions in ext_ua_edr without consiering around 100 tantivy search results, which is a LOT of CPU time to do comparisons on it. We also couldn't match all in ext_gb_coh_psc, I think even with 100 tantivy search results.

## cause

We were creating distinct term queries for each token (split on punctuation and whitespace) to fake a term set query, because we didn't get good results at all when using the tantivy term_set_query.

This meant that scores for tokens repeated in multiple names were adding up. For entities with many names, e.g. big clusters of merged entities, words like ["joint", "stock", "company"] were bumping the score for many results that contain these words. Their IDF should have counted against them so that the rare words count more, but their repetition negated that, meaning the results with the rare matching words unique to the query entity don't rank as well as they should.

## solution

make sure we only count the score for each token in non-phrase queries once (stop common words drowning out the unique and relevant words)

## other changes

1. Consider two tokens in a name a phrase query (previously only 3 and up)
2. make the phrase query slop slightly variable based on number of words
3. Skip building the index if the index directory exists (speed up development)