### PR TITLE
use a method that can shortcut for detecting overlap

### DIFF
--- a/nomenklatura/matching/compare/util.py
+++ b/nomenklatura/matching/compare/util.py
@@ -21,7 +21,7 @@ def has_overlap(
     right: Union[Set[str], List[str]],
 ) -> bool:
     """Returns true if both sequences are non-empty and have common values."""
-    if len(set(left).intersection(right)) > 0:
+    if not set(left).isdisjoint(right):
         return True
     return False
 


### PR DESCRIPTION
We do not need the full intersection here, so we can use [is_disjoint](https://docs.python.org/3.10/library/stdtypes.html#frozenset.isdisjoint) which shortcuts once a match is found.