### PR TITLE
Suggestion for changed Levenshtein lib

### DIFF
--- a/nomenklatura/matching/regression_v2/names.py
+++ b/nomenklatura/matching/regression_v2/names.py
@@ -2,7 +2,7 @@ from typing import Iterable, List, Set
 from normality import WS
 from followthemoney.proxy import E
 from followthemoney.types import registry
-from rigour.text.distance import levenshtein
+from fxkk import levenshtein
 
 from nomenklatura.matching.util import max_in_sets, props_pair, type_pair
 from nomenklatura.matching.compare.util import is_disjoint, has_overlap
@@ -29,7 +29,7 @@ def _name_norms(names: Iterable[str]) -> List[str]:
 
 
 def _compare_levenshtein(left: str, right: str) -> float:
-    distance = levenshtein(left, right)
+    distance = int(levenshtein(left, right))
     base = max((1, len(left), len(right)))
     return 1.0 - (distance / float(base))
     # return math.sqrt(distance)


### PR DESCRIPTION
I figured we're leaving some performance on the floor with our choice of Levenshtein implementation, so I tried out a homerolled version and compared it to Jellyfish. 
These are the results of an xref against some OFAC entities:
Jellyfish
![image](https://github.com/user-attachments/assets/c956ea57-140c-419a-abc1-d0964837c32b)

New
![image](https://github.com/user-attachments/assets/f99c8542-c047-4397-b7c4-79b6cd1e1c7f)

5-7x speedup fits pretty well with what I've seen from automated performance testing. There are probably other libraries we can use as well though we'd need to compile them for Python. 