### PR TITLE
db resolver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,29 @@ jobs:
       matrix:
         python:
           - "3.12"
+        db_url:
+          - "postgresql://nomenklatura:nomenklatura@localhost:5432/nomenklatura"
+          - "sqlite:///:memory:"
+
+    services:
+      # Label used to access the service container
+      db:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_USER: nomenklatura
+          POSTGRES_PASSWORD: nomenklatura
+          POSTGRES_DB: nomenklatura
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -29,6 +52,8 @@ jobs:
         run: |
           make typecheck
       - name: Run tests
+        env:
+          NOMENKLATURA_DB_URL: ${{ matrix.db_url }}
         run: |
           make test
       - name: Build a distribution

--- a/README.md
+++ b/README.md
@@ -20,17 +20,19 @@ With the file in place, you will cross-reference the entities to generate de-dup
 
 ```bash
 # generate merge candidates using an in-memory index:
-$ nomenklatura xref -r resolver.json entities.ijson
-# note there is now a new file, `resolver.json` that contains de-duplication info.
-$ nomenklatura dedupe -r resolver.json entities.ijson
+$ nomenklatura xref entities.ijson
+# note there is now a sqlite database, `nomenklatura.db` that contains de-duplication info.
+$ nomenklatura dedupe entities.ijson
 # will pop up a user interface.
-$ nomenklatura apply entities.ijson -o merged.ijson -r resolver.json
+$ nomenklatura apply entities.ijson -o merged.ijson
 # de-duplicated data goes into `merged.ijson`:
 $ cat entities.ijson | wc -l 
 474
 $ cat merged.ijson | wc -l 
 468 
 ```
+
+The resolver graph database location can be customised by setting the environment variable `NOMENKLATURA_DB_URL`
 
 ### Programmatic usage
 

--- a/nomenklatura/cli.py
+++ b/nomenklatura/cli.py
@@ -71,7 +71,6 @@ def xref_file(
     algorithm: str = DefaultAlgorithm.NAME,
     limit: int = 5000,
     scored: bool = True,
-    index: str = Index.name,
     clear: bool = False,
 ) -> None:
     resolver = Resolver[Entity].make_default()

--- a/nomenklatura/cli.py
+++ b/nomenklatura/cli.py
@@ -75,6 +75,7 @@ def xref_file(
 ) -> None:
     resolver = Resolver[Entity].make_default()
     resolver.begin()
+    resolver.warm_linker()
     store = load_entity_file_store(path, resolver=resolver)
     algorithm_type = get_algorithm(algorithm)
     if algorithm_type is None:
@@ -152,6 +153,7 @@ def make_sortable(path: Path, outpath: Path) -> None:
 def dedupe(path: Path, xref: bool = False) -> None:
     resolver = Resolver[Entity].make_default()
     resolver.begin()
+    resolver.warm_linker()
     store = load_entity_file_store(path, resolver=resolver)
     if xref:
         index_dir = path.parent / INDEX_SEGMENT

--- a/nomenklatura/cli.py
+++ b/nomenklatura/cli.py
@@ -10,7 +10,6 @@ from followthemoney.cli.util import path_entities, write_entity
 from followthemoney.cli.aggregate import sorted_aggregate
 
 from nomenklatura.cache import Cache
-from nomenklatura.index import Index
 from nomenklatura.matching import train_v2_matcher, train_v1_matcher
 from nomenklatura.store import load_entity_file_store
 from nomenklatura.resolver import Resolver
@@ -301,7 +300,7 @@ def load_resolver(source: Path) -> None:
 def dump_resolver(target: Path) -> None:
     resolver = Resolver[Entity].make_default()
     resolver.begin()
-    resolver.save(target)
+    resolver.dump(target)
     resolver.rollback()
 
 

--- a/nomenklatura/cli.py
+++ b/nomenklatura/cli.py
@@ -4,7 +4,7 @@ import yaml
 import click
 import logging
 from pathlib import Path
-from typing import Generator, Iterable, List, Optional, Tuple
+from typing import Generator, List, Optional, Tuple
 from followthemoney.cli.util import path_writer, InPath, OutPath
 from followthemoney.cli.util import path_entities, write_entity
 from followthemoney.cli.aggregate import sorted_aggregate
@@ -47,11 +47,6 @@ def _load_enricher(path: Path) -> Tuple[Dataset, Enricher[Dataset]]:
         return dataset, enricher
 
 
-def _get_resolver(file_path: Path, resolver_path: Optional[Path]) -> Resolver[Entity]:
-    path = resolver_path or _path_sibling(file_path, ".rslv.ijson")
-    return Resolver[Entity].load(Path(path))
-
-
 @click.group(help="Nomenklatura data integration")
 def cli() -> None:
     logging.basicConfig(level=logging.INFO)
@@ -59,7 +54,6 @@ def cli() -> None:
 
 @cli.command("xref", help="Generate dedupe candidates")
 @click.argument("path", type=InPath)
-@click.option("-r", "--resolver", type=ResPath)
 @click.option("-a", "--auto-threshold", type=click.FLOAT, default=None)
 @click.option("-l", "--limit", type=click.INT, default=5000)
 @click.option("--algorithm", default=DefaultAlgorithm.NAME)
@@ -73,7 +67,6 @@ def cli() -> None:
 )
 def xref_file(
     path: Path,
-    resolver: Optional[Path] = None,
     auto_threshold: Optional[float] = None,
     algorithm: str = DefaultAlgorithm.NAME,
     limit: int = 5000,
@@ -81,8 +74,9 @@ def xref_file(
     index: str = Index.name,
     clear: bool = False,
 ) -> None:
-    resolver_ = _get_resolver(path, resolver)
-    store = load_entity_file_store(path, resolver=resolver_)
+    resolver = Resolver[Entity].make_default()
+    resolver.begin()
+    store = load_entity_file_store(path, resolver=resolver)
     algorithm_type = get_algorithm(algorithm)
     if algorithm_type is None:
         raise click.Abort(f"Unknown algorithm: {algorithm}")
@@ -93,9 +87,8 @@ def xref_file(
     if clear and index_dir.exists():
         log.info("Clearing index: %s", index_dir)
         shutil.rmtree(index_dir, ignore_errors=True)
-
     run_xref(
-        resolver_,
+        resolver,
         store,
         index_dir,
         auto_threshold=auto_threshold,
@@ -103,16 +96,16 @@ def xref_file(
         scored=scored,
         limit=limit,
     )
-    resolver_.save()
-    log.info("Xref complete in: %s", resolver_.path)
+    resolver.commit()
+    log.info("Xref complete in: %r", resolver)
 
 
 @cli.command("prune", help="Remove dedupe candidates")
-@click.argument("resolver", type=ResPath)
-def xref_prune(resolver: Path) -> None:
-    resolver_ = _get_resolver(resolver, resolver)
-    resolver_.prune()
-    resolver_.save()
+def xref_prune() -> None:
+    resolver = Resolver[Entity].make_default()
+    resolver.begin()
+    resolver.prune()
+    resolver.commit()
 
 
 @cli.command("apply", help="Apply resolver to an entity stream")
@@ -125,14 +118,14 @@ def xref_prune(resolver: Path) -> None:
     default=None,
     help="Add a dataset to the entity metadata",
 )
-@click.option("-r", "--resolver", required=True, type=ResPath)
-def apply(
-    path: Path, outpath: Path, resolver: Optional[Path], dataset: Optional[str] = None
-) -> None:
-    resolver_ = _get_resolver(path, resolver)
+def apply(path: Path, outpath: Path, dataset: Optional[str] = None) -> None:
+    resolver = Resolver[Entity].make_default()
+    resolver.begin()
+    linker = resolver.get_linker()
+    resolver.rollback()
     with path_writer(outpath) as outfh:
         for proxy in path_entities(path, StreamEntity):
-            proxy = resolver_.apply_stream(proxy)
+            proxy = linker.apply_stream(proxy)
             if dataset is not None:
                 proxy.datasets.add(dataset)
             write_entity(outfh, proxy)
@@ -157,26 +150,16 @@ def make_sortable(path: Path, outpath: Path) -> None:
 @cli.command("dedupe", help="Interactively judge xref candidates")
 @click.argument("path", type=InPath)
 @click.option("-x", "--xref", is_flag=True, default=False)
-@click.option("-r", "--resolver", type=ResPath)
-def dedupe(path: Path, xref: bool = False, resolver: Optional[Path] = None) -> None:
-    resolver_ = _get_resolver(path, resolver)
-    store = load_entity_file_store(path, resolver=resolver_)
+def dedupe(path: Path, xref: bool = False) -> None:
+    resolver = Resolver[Entity].make_default()
+    resolver.begin()
+    store = load_entity_file_store(path, resolver=resolver)
     if xref:
         index_dir = path.parent / INDEX_SEGMENT
-        run_xref(resolver_, store, index_dir)
+        run_xref(resolver, store, index_dir)
+    resolver.commit()
 
-    dedupe_ui(resolver_, store)
-    resolver_.save()
-
-
-@cli.command("merge-resolver", help="Merge resolver configs")
-@click.argument("outpath", type=OutPath)
-@click.option("-i", "--inputs", type=InPath, multiple=True)
-def merge_resolver(outpath: Path, inputs: Iterable[Path]) -> None:
-    resolver = Resolver[Entity].load(outpath)
-    for path in inputs:
-        resolver.merge(path)
-    resolver.save()
+    dedupe_ui(resolver, store)
 
 
 @cli.command("train-v1-matcher", help="Train a matching model from judgement pairs")
@@ -195,22 +178,22 @@ def train_v2_matcher_(pairs_file: Path) -> None:
 @click.argument("config", type=InPath)
 @click.argument("entities", type=InPath)
 @click.option("-o", "--outpath", type=OutPath, default="-")
-@click.option("-r", "--resolver", type=ResPath)
 def match_command(
     config: Path,
     entities: Path,
     outpath: Path,
-    resolver: Optional[Path],
 ) -> None:
-    resolver_ = _get_resolver(entities, resolver)
+    resolver = Resolver[Entity].make_default()
     _, enricher = _load_enricher(config)
+
     try:
+        resolver.begin()
         with path_writer(outpath) as fh:
             stream = path_entities(entities, Entity)
-            for proxy in match(enricher, resolver_, stream):
+            for proxy in match(enricher, resolver, stream):
                 write_entity(fh, proxy)
+        resolver.commit()
     finally:
-        resolver_.save()
         enricher.close()
 
 
@@ -218,20 +201,20 @@ def match_command(
 @click.argument("config", type=InPath)
 @click.argument("entities", type=InPath)
 @click.option("-o", "--outpath", type=OutPath, default="-")  # noqa
-@click.option("-r", "--resolver", type=ResPath)
 def enrich_command(
     config: Path,
     entities: Path,
     outpath: Path,
-    resolver: Optional[Path],
 ) -> None:
-    resolver_ = _get_resolver(entities, resolver)
+    resolver = Resolver[Entity].make_default()
     _, enricher = _load_enricher(config)
     try:
+        resolver.begin()
         with path_writer(outpath) as fh:
             stream = path_entities(entities, Entity)
-            for proxy in enrich(enricher, resolver_, stream):
+            for proxy in enrich(enricher, resolver, stream):
                 write_entity(fh, proxy)
+        resolver.commit()
     finally:
         enricher.close()
 
@@ -254,13 +237,15 @@ def entity_statements(path: Path, outpath: Path, dataset: str, format: str) -> N
 @click.option("-i", "--infile", type=InPath, default="-")
 @click.option("-o", "--outpath", type=OutPath, default="-")
 @click.option("-f", "--format", type=click.Choice(FORMATS), default=CSV)
-@click.option("-r", "--resolver", required=True, type=ResPath)
-def statements_apply(infile: Path, outpath: Path, format: str, resolver: Path) -> None:
-    resolver_ = _get_resolver(infile, resolver)
+def statements_apply(infile: Path, outpath: Path, format: str) -> None:
+    resolver = Resolver[Entity].make_default()
+    resolver.begin()
+    linker = resolver.get_linker()
+    resolver.rollback()
 
     def _generate() -> Generator[Statement, None, None]:
         for stmt in read_path_statements(infile, format=format):
-            yield resolver_.apply_statement(stmt)
+            yield linker.apply_statement(stmt)
 
     with path_writer(outpath) as outfh:
         write_statements(outfh, format, _generate())
@@ -299,6 +284,24 @@ def statements_aggregate(
         if len(statements):
             entity = Entity.from_statements(dataset_, statements)
             write_entity(outfh, entity)
+
+
+@cli.command("load-resolver", help="Load resolver decisions from file into database")
+@click.argument("source", type=InPath)
+def load_resolver(source: Path) -> None:
+    resolver = Resolver[Entity].make_default()
+    resolver.begin()
+    resolver.load(source)
+    resolver.commit()
+
+
+@cli.command("dump-resolver", help="Dump resolver decisions from database to file")
+@click.argument("target", type=OutPath)
+def dump_resolver(target: Path) -> None:
+    resolver = Resolver[Entity].make_default()
+    resolver.begin()
+    resolver.save(target)
+    resolver.rollback()
 
 
 @cli.command("bench", help="Benchmark a matching algorithm")

--- a/nomenklatura/cli.py
+++ b/nomenklatura/cli.py
@@ -285,7 +285,7 @@ def statements_aggregate(
             write_entity(outfh, entity)
 
 
-@cli.command("load-resolver", help="Load resolver decisions from file into database")
+@cli.command("load-resolver", help="Load resolver edges from file into database")
 @click.argument("source", type=InPath)
 def load_resolver(source: Path) -> None:
     resolver = Resolver[Entity].make_default()

--- a/nomenklatura/db.py
+++ b/nomenklatura/db.py
@@ -34,7 +34,7 @@ def get_engine(url: Optional[str] = None) -> Engine:
 
     connect_args = {}
     if url.startswith("postgres"):
-        connect_args["options"] = "-c statement_timeout=3000"
+        connect_args["options"] = f"-c statement_timeout={settings.DB_STMT_TIMEOUT}"
 
     return create_engine(
         url, pool_size=settings.DB_POOL_SIZE, connect_args=connect_args

--- a/nomenklatura/resolver/edge.py
+++ b/nomenklatura/resolver/edge.py
@@ -6,8 +6,16 @@ from nomenklatura.resolver.identifier import Identifier, StrIdent
 
 
 class Edge(object):
-
-    __slots__ = ("key", "source", "target", "judgement", "score", "user", "timestamp")
+    __slots__ = (
+        "key",
+        "source",
+        "target",
+        "judgement",
+        "score",
+        "user",
+        "created_at",
+        "deleted_at",
+    )
 
     def __init__(
         self,
@@ -16,14 +24,16 @@ class Edge(object):
         judgement: Judgement = Judgement.NO_JUDGEMENT,
         score: Optional[float] = None,
         user: Optional[str] = None,
-        timestamp: Optional[str] = None,
+        created_at: Optional[str] = None,
+        deleted_at: Optional[str] = None,
     ):
         self.key = Identifier.pair(left_id, right_id)
         self.target, self.source = self.key
         self.judgement = judgement
         self.score = score
         self.user = user
-        self.timestamp = timestamp
+        self.created_at = created_at
+        self.deleted_at = deleted_at
 
     def other(self, cur: Identifier) -> Identifier:
         if cur == self.target:
@@ -37,7 +47,8 @@ class Edge(object):
             "judgement": self.judgement.value,
             "score": self.score,
             "user": self.user,
-            "timestamp": self.timestamp,
+            "created_at": self.created_at,
+            "deleted_at": self.deleted_at,
         }
 
     def to_line(self) -> str:
@@ -47,7 +58,7 @@ class Edge(object):
             self.judgement.value,
             self.score,
             self.user,
-            self.timestamp,
+            self.created_at,
         ]
         return json.dumps(row) + "\n"
 
@@ -69,14 +80,17 @@ class Edge(object):
     @classmethod
     def from_line(cls, line: str) -> "Edge":
         data = json.loads(line)
-        return cls(
+        edge = cls(
             data[0],
             data[1],
             judgement=Judgement(data[2]),
             score=data[3],
             user=data[4],
-            timestamp=data[5],
+            created_at=data[5],
         )
+        if len(data) > 6:
+            edge.deleted_at = data[6]
+        return edge
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Edge":
@@ -86,5 +100,6 @@ class Edge(object):
             judgement=Judgement(data["judgement"]),
             score=data["score"],
             user=data["user"],
-            timestamp=data["timestamp"],
+            created_at=data.get("created_at"),
+            deleted_at=data.get("deleted_at"),
         )

--- a/nomenklatura/resolver/edge.py
+++ b/nomenklatura/resolver/edge.py
@@ -1,5 +1,6 @@
 import json
-from typing import Any, Optional
+from typing import Any, Dict, Optional, Union
+from sqlalchemy.engine import RowMapping
 
 from nomenklatura.judgement import Judgement
 from nomenklatura.resolver.identifier import Identifier, StrIdent
@@ -29,6 +30,16 @@ class Edge(object):
         if cur == self.target:
             return self.source
         return self.target
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "target": self.target.id,
+            "source": self.source.id,
+            "judgement": self.judgement.value,
+            "score": self.score,
+            "user": self.user,
+            "timestamp": self.timestamp,
+        }
 
     def to_line(self) -> str:
         row = [
@@ -66,4 +77,15 @@ class Edge(object):
             score=data[3],
             user=data[4],
             timestamp=data[5],
+        )
+
+    @classmethod
+    def from_dict(cls, data: Union[RowMapping, Dict[str, Any]]) -> "Edge":
+        return cls(
+            left_id=data["target"],
+            right_id=data["source"],
+            judgement=Judgement(data["judgement"]),
+            score=data["score"],
+            user=data["user"],
+            timestamp=data["timestamp"],
         )

--- a/nomenklatura/resolver/edge.py
+++ b/nomenklatura/resolver/edge.py
@@ -1,5 +1,7 @@
 import json
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
+
+from sqlalchemy.engine import RowMapping
 
 from nomenklatura.judgement import Judgement
 from nomenklatura.resolver.identifier import Identifier, StrIdent
@@ -93,7 +95,7 @@ class Edge(object):
         return edge
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Edge":
+    def from_dict(cls, data: Union[RowMapping, Dict[str, Any]]) -> "Edge":
         return cls(
             left_id=data["target"],
             right_id=data["source"],

--- a/nomenklatura/resolver/edge.py
+++ b/nomenklatura/resolver/edge.py
@@ -1,6 +1,5 @@
 import json
-from typing import Any, Dict, Optional, Union
-from sqlalchemy.engine import RowMapping
+from typing import Any, Dict, Optional
 
 from nomenklatura.judgement import Judgement
 from nomenklatura.resolver.identifier import Identifier, StrIdent
@@ -80,7 +79,7 @@ class Edge(object):
         )
 
     @classmethod
-    def from_dict(cls, data: Union[RowMapping, Dict[str, Any]]) -> "Edge":
+    def from_dict(cls, data: Dict[str, Any]) -> "Edge":
         return cls(
             left_id=data["target"],
             right_id=data["source"],

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -215,7 +215,7 @@ class Resolver(Linker[CE]):
         # Nodes from edges
         stmt_sources = select(cte_inner.c.source.label("node"))
         stmt_targets = select(cte_inner.c.target.label("node"))
-        cte_outer = stmt_sources.union(stmt_targets)
+        cte_outer = stmt_sources.union(stmt_targets).subquery()
 
         stmt = select(cte_outer.c.node)
         connected = set([node])

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -5,7 +5,6 @@ import getpass
 import logging
 from functools import lru_cache
 from typing import Dict, Generator, Optional, Set, Tuple
-from urllib.parse import urlunparse
 
 from followthemoney.types import registry
 from rigour.ids.wikidata import is_qid
@@ -537,14 +536,5 @@ class Resolver(Linker[CE]):
 
     def __repr__(self) -> str:
         parts = self._engine.url
-        url = urlunparse(
-            (
-                parts.drivername,
-                parts.host,
-                f"/{parts.database}/{self._table.name}",
-                None,
-                None,
-                None,
-            )
-        )
+        url = f"{parts.drivername}://{parts.host or ""}/{parts.database}/{self._table.name}"
         return f"<Resolver({url})>"

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -377,7 +377,6 @@ class Resolver(Linker[CE]):
         judgement: Judgement,
         user: Optional[str] = None,
         score: Optional[float] = None,
-        timestamp: Optional[str] = None,
     ) -> Identifier:
         edge = self.get_edge(left_id, right_id)
         if edge is None:
@@ -397,7 +396,7 @@ class Resolver(Linker[CE]):
                 return canonical
 
         edge.judgement = judgement
-        edge.timestamp = timestamp or utc_now().isoformat()[:28]
+        edge.timestamp = utc_now().isoformat()[:28]
         edge.user = user or getpass.getuser()
         edge.score = score or edge.score
         self._register(edge)
@@ -497,11 +496,6 @@ class Resolver(Linker[CE]):
                 if not line:
                     break
                 edge = Edge.from_line(line)
-                # There exist legacy positive edges which don't lead to a canonical.
-                # If we load these edges using self.decide, some of them generate
-                # canonicals which are greater than the current canonicals connected
-                # to these edges. This could imply lots of unplanned rekeying.
-                # So let's just register the edges as they are for now.
                 self._register(edge)
         self._invalidate()
 

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -219,19 +219,26 @@ class Resolver(Linker[CE]):
             referents.add(connected.id)
         return referents
 
-    def get_resolved_edge(
+    def _get_resolved_edges(
         self, left_id: StrIdent, right_id: StrIdent
-    ) -> Optional[Edge]:
+    ) -> Generator[Edge, None, None]:
         (left, right) = Identifier.pair(left_id, right_id)
         left_connected = self.connected(left)
         right_connected = self.connected(right)
         for e in left_connected:
             for o in right_connected:
+                if e == o:
+                    continue
                 edge = self.get_edge(e, o)
                 if edge is None:
                     continue
-                return edge
-        return None
+                yield edge
+
+    def get_resolved_edge(
+        self, left_id: StrIdent, right_id: StrIdent
+    ) -> Optional[Edge]:
+        """Some edge between left and right, if any."""
+        return next(self._get_resolved_edges(left_id, right_id), None)
 
     def _pair_judgement(self, left: Identifier, right: Identifier) -> Judgement:
         edge = self.get_edge(left, right)

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -54,7 +54,7 @@ class Resolver(Linker[CE]):
             Column("judgement", Unicode(14), nullable=False),
             Column("score", Float, nullable=True),
             Column("user", Unicode(512), nullable=False),
-            Column("timestamp", Unicode(28)),
+            Column("created_at", Unicode(28)),
             Column("deleted_at", Unicode(28), nullable=True),
             extend_existing=True,
         )
@@ -359,7 +359,7 @@ class Resolver(Linker[CE]):
         stmt = self._table.select()
         stmt = stmt.where(self._table.c.judgement != Judgement.NO_JUDGEMENT.value)
         stmt = stmt.where(self._table.c.deleted_at.is_(None))
-        stmt = stmt.order_by(self._table.c.timestamp.desc())
+        stmt = stmt.order_by(self._table.c.created_at.desc())
         if limit is not None:
             stmt = stmt.limit(limit)
         cursor = self._get_connection().execute(stmt)
@@ -440,7 +440,7 @@ class Resolver(Linker[CE]):
                 return canonical
 
         edge.judgement = judgement
-        edge.timestamp = timestamp()
+        edge.created_at = timestamp()
         edge.user = user or getpass.getuser()
         edge.score = score or edge.score
         self._register(edge)
@@ -456,7 +456,7 @@ class Resolver(Linker[CE]):
             judgement=istmt.excluded.judgement,
             score=istmt.excluded.score,
             user=istmt.excluded.user,
-            timestamp=istmt.excluded.timestamp,
+            created_at=istmt.excluded.created_at,
             deleted_at=None,
         )
         stmt = istmt.on_conflict_do_update(

--- a/nomenklatura/settings.py
+++ b/nomenklatura/settings.py
@@ -1,13 +1,14 @@
 from pathlib import Path
-from rigour.env import env_str
+from rigour.env import env_str, env_int
 
 TESTING = False
 
 DB_PATH = Path("nomenklatura.db").resolve()
 DB_URL = env_str("NOMENKLATURA_DB_URL", "")
-DB_POOL_SIZE = int(env_str("NOMENKLATURA_DB_POOL_SIZE", "5"))
+DB_POOL_SIZE = env_int("NOMENKLATURA_DB_POOL_SIZE", 5)
+DB_STMT_TIMEOUT = env_int("NOMENKLATURA_DB_STMT_TIMEOUT", 10000)
 
 REDIS_URL = env_str("NOMENKLATURA_REDIS_URL", "")
 
 STATEMENT_TABLE = env_str("NOMENKLATURA_STATEMENT_TABLE", "statement")
-STATEMENT_BATCH = int(env_str("NOMENKLATURA_STATEMENT_BATCH", "10000"))
+STATEMENT_BATCH = env_int("NOMENKLATURA_STATEMENT_BATCH", 3000)

--- a/nomenklatura/settings.py
+++ b/nomenklatura/settings.py
@@ -4,7 +4,7 @@ from rigour.env import env_str
 TESTING = False
 
 DB_PATH = Path("nomenklatura.db").resolve()
-DB_URL = env_str("NOMENKLATURA_DB_URL", f"sqlite:///{DB_PATH.as_posix()}")
+DB_URL = env_str("NOMENKLATURA_DB_URL", "")
 DB_POOL_SIZE = int(env_str("NOMENKLATURA_DB_POOL_SIZE", "5"))
 
 REDIS_URL = env_str("NOMENKLATURA_REDIS_URL", "")

--- a/nomenklatura/store/__init__.py
+++ b/nomenklatura/store/__init__.py
@@ -25,13 +25,11 @@ __all__ = [
 
 def load_entity_file_store(
     path: Path,
-    resolver: Optional[Resolver[CompositeEntity]] = None,
+    resolver: Resolver[CompositeEntity],
     dataset: Optional[Dataset] = None,
     cleaned: bool = True,
 ) -> SimpleMemoryStore:
     """Create a simple in-memory store by reading FtM entities from a file path."""
-    if resolver is None:
-        resolver = Resolver[CompositeEntity]()
     if dataset is None:
         dataset = Dataset.make({"name": path.stem, "title": path.stem})
     store = MemoryStore(dataset, resolver)

--- a/nomenklatura/tui/app.py
+++ b/nomenklatura/tui/app.py
@@ -110,7 +110,7 @@ class HistoryItem(Static, DedupeAppWidget):
             target_str += f"\n     {target.caption}"
 
         content = (
-            f"{edge.timestamp if edge.timestamp else 'unknown time'}\n"
+            f"{edge.created_at if edge.created_at else 'unknown time'}\n"
             f"{source_str}\n"
             f"{target_str}\n"
             f"{edge.user} decided {edge.judgement.value}"

--- a/nomenklatura/tui/app.py
+++ b/nomenklatura/tui/app.py
@@ -68,7 +68,8 @@ class DedupeState(object):
     def decide(self, judgement: Judgement) -> None:
         if self.left is not None and self.left.id is not None:
             if self.right is not None and self.right.id is not None:
-                # Hold on to pre-merge entities to show in history.
+                # Since we don't have an unresolved store as well as the resolved one,
+                # hold on to pre-merge entities to show in history.
                 self.recents[self.left.id] = self.left
                 self.recents[self.right.id] = self.right
                 canonical_id = self.resolver.decide(
@@ -82,6 +83,8 @@ class DedupeState(object):
 
     def edit(self, edge: Edge, judgement: Judgement) -> None:
         self.resolver.decide(edge.source, edge.target, judgement)
+        self.store.update(edge.source)
+        self.store.update(edge.target)
         self.resolver.commit()
         self.load()
 

--- a/nomenklatura/tui/app.tcss
+++ b/nomenklatura/tui/app.tcss
@@ -1,0 +1,53 @@
+CompareWidget:focus {
+    background: #222222;
+}
+
+ConfirmEditModal {
+    align: center middle;
+}
+
+#dialog {
+    grid-size: 2;
+    grid-gutter: 1 2;
+    grid-rows: 1fr 3;
+    padding: 0 1;
+    width: 60;
+    height: 11;
+    border: thick $background 80%;
+    background: $surface;
+}
+
+#question {
+    column-span: 2;
+    height: 1fr;
+    width: 1fr;
+    content-align: center middle;
+}
+
+
+HistoryItem {
+    border: solid white;
+}
+
+HistoryWidget {
+    width: 50;
+    border: solid white;
+}
+
+HistoryWidget > .help {
+    padding: 1
+}
+
+DedupeWidget {
+    layout: horizontal;
+    overflow-x: auto;
+}
+
+CompareWidget {
+    height: auto;
+    width: 1fr;
+}
+
+DedupeApp {
+    layout: vertical;
+}

--- a/nomenklatura/xref.py
+++ b/nomenklatura/xref.py
@@ -107,6 +107,7 @@ def xref(
                 score = (score + 1.0) / 2.0
 
             resolver.suggest(left.id, right.id, score, user=user)
+
             if suggested >= limit:
                 break
             suggested += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,3 +73,7 @@ universal = true
 
 [tool.coverage.run]
 branch = true
+
+[tool.pytest.ini_options]
+# Log a stack trace when a test takes longer than 300 seconds
+faulthandler_timeout = 300

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
     "plyvel < 2.0.0",
     "redis > 5.0.0, < 6.0.0",
     "tantivy < 1.0.0",
+    "psycopg2-binary",
 ]
 leveldb = ["plyvel < 2.0.0"]
 redis = ["redis > 5.0.0, < 6.0.0"]

--- a/tests/enrich/test_nominatim.py
+++ b/tests/enrich/test_nominatim.py
@@ -88,6 +88,7 @@ def test_nominatim_match():
 
 
 def test_nominatim_match_list(resolver: Resolver[CompositeEntity]):
+    resolver.begin()
     enricher = load_enricher()
 
     full = "Kopenhagener Str. 47, Berlin"
@@ -116,6 +117,7 @@ def test_nominatim_enrich():
 
 
 def test_nominatim_enrich_list(resolver: Resolver[CompositeEntity]):
+    resolver.begin()
     enricher = load_enricher()
 
     full = "Kopenhagener Str. 47, Berlin"

--- a/tests/enrich/test_nominatim.py
+++ b/tests/enrich/test_nominatim.py
@@ -87,21 +87,21 @@ def test_nominatim_match():
         assert len(results) == 0, results
 
 
-def test_nominatim_match_list():
+def test_nominatim_match_list(resolver: Resolver[CompositeEntity]):
     enricher = load_enricher()
 
     full = "Kopenhagener Str. 47, Berlin"
     data = {"schema": "Address", "id": "xxx", "properties": {"full": [full]}}
     ent = CompositeEntity.from_data(dataset, data)
 
-    resolver = Resolver()
-    assert len(resolver.edges) == 0, resolver.edges
+    candidates = list(resolver.get_candidates())
+    assert len(candidates) == 0, candidates
     with requests_mock.Mocker(real_http=False) as m:
         m.get("/search.php", json=RESPONSE)
         results = list(match(enricher, resolver, [ent]))
     assert len(results) == 2, results
-    assert len(resolver.edges) == 1, resolver.edges
-    assert list(resolver.edges.values())[0].judgement == Judgement.NO_JUDGEMENT
+    candidates = list(resolver.get_candidates())
+    assert len(candidates) == 1, candidates
 
 
 def test_nominatim_enrich():
@@ -115,7 +115,7 @@ def test_nominatim_enrich():
     assert len(adjacent) == 1, adjacent
 
 
-def test_nominatim_enrich_list():
+def test_nominatim_enrich_list(resolver: Resolver[CompositeEntity]):
     enricher = load_enricher()
 
     full = "Kopenhagener Str. 47, Berlin"
@@ -125,7 +125,6 @@ def test_nominatim_enrich_list():
 
     with requests_mock.Mocker(real_http=False) as m:
         m.get("/search.php", json=RESPONSE)
-        resolver = Resolver()
         results = list(enrich(enricher, resolver, [ent]))
         assert len(results) == 0, results
         resolver.decide(ent.id, "osm-node-2140755199", judgement=Judgement.POSITIVE)

--- a/tests/store/test_leveldb.py
+++ b/tests/store/test_leveldb.py
@@ -26,6 +26,7 @@ PERSON_EXT = {
 def test_leveldb_store_basics(
     test_dataset: Dataset, resolver: Resolver[CompositeEntity]
 ):
+    resolver.begin()
     path = Path(tempfile.mkdtemp()) / "leveldb"
     store = LevelDBStore(test_dataset, resolver, path)
     entity = CompositeEntity.from_data(test_dataset, PERSON)
@@ -52,6 +53,7 @@ def test_leveldb_store_basics(
 def test_leveldb_graph_query(
     donations_path: Path, test_dataset: Dataset, resolver: Resolver[CompositeEntity]
 ):
+    resolver.begin()
     path = Path(tempfile.mkdtemp()) / "xxx"
     store = LevelDBStore(test_dataset, resolver, path)
     assert len(list(store.view(test_dataset).entities())) == 0

--- a/tests/store/test_leveldb.py
+++ b/tests/store/test_leveldb.py
@@ -23,9 +23,10 @@ PERSON_EXT = {
 }
 
 
-def test_leveldb_store_basics(test_dataset: Dataset):
+def test_leveldb_store_basics(
+    test_dataset: Dataset, resolver: Resolver[CompositeEntity]
+):
     path = Path(tempfile.mkdtemp()) / "leveldb"
-    resolver = Resolver[CompositeEntity]()
     store = LevelDBStore(test_dataset, resolver, path)
     entity = CompositeEntity.from_data(test_dataset, PERSON)
     entity_ext = CompositeEntity.from_data(test_dataset, PERSON_EXT)
@@ -48,9 +49,10 @@ def test_leveldb_store_basics(test_dataset: Dataset):
     assert len(list(store.view(test_dataset).entities())) == 1
 
 
-def test_leveldb_graph_query(donations_path: Path, test_dataset: Dataset):
+def test_leveldb_graph_query(
+    donations_path: Path, test_dataset: Dataset, resolver: Resolver[CompositeEntity]
+):
     path = Path(tempfile.mkdtemp()) / "xxx"
-    resolver = Resolver[CompositeEntity]()
     store = LevelDBStore(test_dataset, resolver, path)
     assert len(list(store.view(test_dataset).entities())) == 0
     with store.writer() as writer:

--- a/tests/store/test_memory.py
+++ b/tests/store/test_memory.py
@@ -22,6 +22,7 @@ PERSON_EXT = {
 
 
 def test_basic_store(test_dataset: Dataset, resolver: Resolver[CompositeEntity]):
+    resolver.begin()
     store = MemoryStore(test_dataset, resolver)
     entity = CompositeEntity.from_data(test_dataset, PERSON)
     entity_ext = CompositeEntity.from_data(test_dataset, PERSON_EXT)

--- a/tests/store/test_memory.py
+++ b/tests/store/test_memory.py
@@ -21,8 +21,7 @@ PERSON_EXT = {
 }
 
 
-def test_basic_store(test_dataset: Dataset):
-    resolver = Resolver[CompositeEntity]()
+def test_basic_store(test_dataset: Dataset, resolver: Resolver[CompositeEntity]):
     store = MemoryStore(test_dataset, resolver)
     entity = CompositeEntity.from_data(test_dataset, PERSON)
     entity_ext = CompositeEntity.from_data(test_dataset, PERSON_EXT)

--- a/tests/store/test_redis.py
+++ b/tests/store/test_redis.py
@@ -23,9 +23,8 @@ PERSON_EXT = {
 }
 
 
-def test_redis_store_basics(test_dataset: Dataset):
+def test_redis_store_basics(test_dataset: Dataset, resolver: Resolver[CompositeEntity]):
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
-    resolver = Resolver[CompositeEntity]()
     store = RedisStore(test_dataset, resolver, db=redis)
     entity = CompositeEntity.from_data(test_dataset, PERSON)
     entity_ext = CompositeEntity.from_data(test_dataset, PERSON_EXT)
@@ -48,9 +47,10 @@ def test_redis_store_basics(test_dataset: Dataset):
     assert len(list(store.view(test_dataset).entities())) == 1
 
 
-def test_leveldb_graph_query(donations_path: Path, test_dataset: Dataset):
+def test_leveldb_graph_query(
+    donations_path: Path, test_dataset: Dataset, resolver: Resolver[CompositeEntity]
+):
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
-    resolver = Resolver[CompositeEntity]()
     store = RedisStore(test_dataset, resolver, db=redis)
     assert len(list(store.view(test_dataset).entities())) == 0
     with store.writer() as writer:

--- a/tests/store/test_redis.py
+++ b/tests/store/test_redis.py
@@ -24,6 +24,7 @@ PERSON_EXT = {
 
 
 def test_redis_store_basics(test_dataset: Dataset, resolver: Resolver[CompositeEntity]):
+    resolver.begin()
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
     store = RedisStore(test_dataset, resolver, db=redis)
     entity = CompositeEntity.from_data(test_dataset, PERSON)
@@ -50,6 +51,7 @@ def test_redis_store_basics(test_dataset: Dataset, resolver: Resolver[CompositeE
 def test_leveldb_graph_query(
     donations_path: Path, test_dataset: Dataset, resolver: Resolver[CompositeEntity]
 ):
+    resolver.begin()
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
     store = RedisStore(test_dataset, resolver, db=redis)
     assert len(list(store.view(test_dataset).entities())) == 0

--- a/tests/store/test_resolved.py
+++ b/tests/store/test_resolved.py
@@ -28,6 +28,7 @@ PERSON_EXT = {
 
 
 def test_store_basics(test_dataset: Dataset, resolver: Resolver[CompositeEntity]):
+    resolver.begin()
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
     store = ResolvedStore(test_dataset, resolver, db=redis)
     entity = CompositeEntity.from_data(test_dataset, PERSON)
@@ -59,6 +60,7 @@ def test_store_basics(test_dataset: Dataset, resolver: Resolver[CompositeEntity]
 def test_graph_query(
     donations_path: Path, test_dataset: Dataset, resolver: Resolver[CompositeEntity]
 ):
+    resolver.begin()
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
     store = ResolvedStore(test_dataset, resolver, db=redis)
     assert len(list(store.view(test_dataset).entities())) == 0
@@ -108,6 +110,7 @@ def test_graph_query(
 def test_custom_functions(
     donations_path: Path, test_dataset: Dataset, resolver: Resolver[CompositeEntity]
 ):
+    resolver.begin()
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
     prefix = "test123"
     mem_store = MemoryStore(test_dataset, resolver)

--- a/tests/store/test_resolved.py
+++ b/tests/store/test_resolved.py
@@ -27,9 +27,8 @@ PERSON_EXT = {
 }
 
 
-def test_store_basics(test_dataset: Dataset):
+def test_store_basics(test_dataset: Dataset, resolver: Resolver[CompositeEntity]):
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
-    resolver = Resolver[CompositeEntity]()
     store = ResolvedStore(test_dataset, resolver, db=redis)
     entity = CompositeEntity.from_data(test_dataset, PERSON)
     entity_ext = CompositeEntity.from_data(test_dataset, PERSON_EXT)
@@ -57,9 +56,10 @@ def test_store_basics(test_dataset: Dataset):
         store.update(merged_id)
 
 
-def test_graph_query(donations_path: Path, test_dataset: Dataset):
+def test_graph_query(
+    donations_path: Path, test_dataset: Dataset, resolver: Resolver[CompositeEntity]
+):
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
-    resolver = Resolver[CompositeEntity]()
     store = ResolvedStore(test_dataset, resolver, db=redis)
     assert len(list(store.view(test_dataset).entities())) == 0
     with store.writer() as writer:
@@ -105,9 +105,10 @@ def test_graph_query(donations_path: Path, test_dataset: Dataset):
     assert not view.has_entity("john-doe-333")
 
 
-def test_custom_functions(donations_path: Path, test_dataset: Dataset):
+def test_custom_functions(
+    donations_path: Path, test_dataset: Dataset, resolver: Resolver[CompositeEntity]
+):
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
-    resolver = Resolver[CompositeEntity]()
     prefix = "test123"
     mem_store = MemoryStore(test_dataset, resolver)
     store = ResolvedStore(test_dataset, resolver, prefix=prefix, db=redis)

--- a/tests/store/test_stores.py
+++ b/tests/store/test_stores.py
@@ -74,6 +74,7 @@ def test_store_sql(
     donations_json: List[Dict[str, Any]],
     resolver: Resolver[CompositeEntity],
 ):
+    resolver.begin()
     uri = f"sqlite:///{tmp_path / 'test.db'}"
     store = SQLStore(dataset=test_dataset, linker=resolver, uri=uri)
     assert str(store.engine.url) == uri
@@ -85,6 +86,7 @@ def test_store_memory(
     donations_json: List[Dict[str, Any]],
     resolver: Resolver[CompositeEntity],
 ):
+    resolver.begin()
     store = SimpleMemoryStore(dataset=test_dataset, linker=resolver)
     assert _run_store_test(store, test_dataset, donations_json)
 
@@ -95,6 +97,7 @@ def test_store_level(
     donations_json: List[Dict[str, Any]],
     resolver: Resolver[CompositeEntity],
 ):
+    resolver.begin()
     path = tmp_path / "level.db"
     store = LevelDBStore(dataset=test_dataset, linker=resolver, path=path)
     assert _run_store_test(store, test_dataset, donations_json)

--- a/tests/store/test_stores.py
+++ b/tests/store/test_stores.py
@@ -69,25 +69,32 @@ def _run_store_test(
 
 
 def test_store_sql(
-    tmp_path: Path, test_dataset: Dataset, donations_json: List[Dict[str, Any]]
+    tmp_path: Path,
+    test_dataset: Dataset,
+    donations_json: List[Dict[str, Any]],
+    resolver: Resolver[CompositeEntity],
 ):
-    resolver = Resolver[CompositeEntity]()
     uri = f"sqlite:///{tmp_path / 'test.db'}"
     store = SQLStore(dataset=test_dataset, linker=resolver, uri=uri)
     assert str(store.engine.url) == uri
     assert _run_store_test(store, test_dataset, donations_json)
 
 
-def test_store_memory(test_dataset: Dataset, donations_json: List[Dict[str, Any]]):
-    resolver = Resolver[CompositeEntity]()
+def test_store_memory(
+    test_dataset: Dataset,
+    donations_json: List[Dict[str, Any]],
+    resolver: Resolver[CompositeEntity],
+):
     store = SimpleMemoryStore(dataset=test_dataset, linker=resolver)
     assert _run_store_test(store, test_dataset, donations_json)
 
 
 def test_store_level(
-    tmp_path: Path, test_dataset: Dataset, donations_json: List[Dict[str, Any]]
+    tmp_path: Path,
+    test_dataset: Dataset,
+    donations_json: List[Dict[str, Any]],
+    resolver: Resolver[CompositeEntity],
 ):
-    resolver = Resolver[CompositeEntity]()
     path = tmp_path / "level.db"
     store = LevelDBStore(dataset=test_dataset, linker=resolver, path=path)
     assert _run_store_test(store, test_dataset, donations_json)

--- a/tests/store/test_versioned.py
+++ b/tests/store/test_versioned.py
@@ -27,6 +27,7 @@ PERSON_EXT = {
 
 
 def test_store_basics(test_dataset: Dataset, resolver: Resolver[CompositeEntity]):
+    resolver.begin()
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
     store = VersionedRedisStore(test_dataset, resolver, db=redis)
     assert len(list(store.view(test_dataset).statements())) == 0
@@ -64,6 +65,7 @@ def test_store_basics(test_dataset: Dataset, resolver: Resolver[CompositeEntity]
 def test_graph_query(
     donations_path: Path, test_dataset: Dataset, resolver: Resolver[CompositeEntity]
 ):
+    resolver.begin()
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
     store = VersionedRedisStore(test_dataset, resolver, db=redis)
     assert len(list(store.view(test_dataset).entities())) == 0

--- a/tests/store/test_versioned.py
+++ b/tests/store/test_versioned.py
@@ -26,9 +26,8 @@ PERSON_EXT = {
 }
 
 
-def test_store_basics(test_dataset: Dataset):
+def test_store_basics(test_dataset: Dataset, resolver: Resolver[CompositeEntity]):
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
-    resolver = Resolver[CompositeEntity]()
     store = VersionedRedisStore(test_dataset, resolver, db=redis)
     assert len(list(store.view(test_dataset).statements())) == 0
     entity = CompositeEntity.from_data(test_dataset, PERSON)
@@ -62,9 +61,10 @@ def test_store_basics(test_dataset: Dataset):
     assert len(list(store.view(test_dataset).statements())) == 5
 
 
-def test_graph_query(donations_path: Path, test_dataset: Dataset):
+def test_graph_query(
+    donations_path: Path, test_dataset: Dataset, resolver: Resolver[CompositeEntity]
+):
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
-    resolver = Resolver[CompositeEntity]()
     store = VersionedRedisStore(test_dataset, resolver, db=redis)
     assert len(list(store.view(test_dataset).entities())) == 0
     with store.writer() as writer:
@@ -117,8 +117,7 @@ def test_graph_query(donations_path: Path, test_dataset: Dataset):
     assert len(list(entity.statements)) == len(list(ext_entity.statements))
 
 
-def test_versioning(test_dataset: Dataset):
-    resolver = Resolver[CompositeEntity]()
+def test_versioning(test_dataset: Dataset, resolver: Resolver[CompositeEntity]):
     store = VersionedRedisStore(test_dataset, resolver)
     assert store.get_latest(test_dataset.name) is None
     assert len(store.get_history(test_dataset.name)) == 0

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -181,7 +181,6 @@ def test_linker(resolver):
 
 
 def test_cached_linker(resolver):
-    resolver = Resolver.make_default()
     resolver.begin()
     canon_a = resolver.decide("a1", "a2", Judgement.POSITIVE)
     assert resolver.get_canonical("a1") == canon_a
@@ -213,8 +212,6 @@ def test_resolver_store_load(resolver, other_table_resolver):
         with open(path, "r") as fh:
             assert len(fh.readlines()) == 4
 
-        get_engine.cache_clear()
-        get_metadata.cache_clear()
         other_table_resolver.begin()
         other_table_resolver.load(path)
         assert len(other_table_resolver.get_edges()) == len(resolver.get_edges())
@@ -245,7 +242,7 @@ def test_resolver_candidates(resolver):
     resolver.commit()
 
 
-def test_get_judgments(resolver):
+def test_get_judgements(resolver):
     resolver.begin()
     canon = resolver.decide("a1", "a2", Judgement.POSITIVE)
     resolver.decide(canon, "a3", Judgement.POSITIVE)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -134,11 +134,9 @@ def test_cluster_to_cluster():
         Identifier.get(a_canon),
         Identifier.get(b_canon),
     }
-    assert expected.issubset(resolver.connected(Identifier.get("a1")))
-
-
-
-
+    connected = resolver.connected(Identifier.get("a1"))
+    assert expected.issubset(connected), (expected, connected)
+    
     resolver.commit()
 
 def test_linker():

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -29,6 +29,7 @@ def test_resolver(resolver):
     a_canon = resolver.decide("a1", "a2", Judgement.POSITIVE)
     assert a_canon.canonical, a_canon
     assert Identifier.get("a2") in resolver.connected(Identifier.get("a1"))
+    assert set(n.id for n in resolver.get_nodes()) == {"a1", "a2", a_canon.id}
 
     assert resolver.get_judgement("a1", "a2") == Judgement.POSITIVE
     resolver.decide("b1", "b2", Judgement.POSITIVE)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
+from nomenklatura import settings
 from nomenklatura.db import get_engine, get_metadata
 from nomenklatura.judgement import Judgement
 from nomenklatura.resolver import Resolver, Identifier
@@ -83,7 +84,12 @@ def test_resolver(resolver):
     assert "a1" in resolver.get_referents(a_canon, canonicals=False)
     # assert a_canon.id in resolver.get_referents(a_canon)
     assert a_canon.id not in resolver.get_referents(a_canon, canonicals=False)
-    assert "sqlite://:memory:" in repr(resolver) or "postgresql://" in repr(resolver)
+    if settings.DB_URL.startswith("sqlite"):
+        assert "sqlite:///:memory:" in repr(resolver)
+    elif settings.DB_URL.startswith("postgres"):
+        assert "postgresql://" in repr(resolver)
+    else:
+        assert False, "Expected DB_URL to start with 'sqlite://' or 'postgres://'"
 
     resolver.explode("a1")
     assert resolver.get_canonical("a17") == "a17"

--- a/tests/test_xref.py
+++ b/tests/test_xref.py
@@ -35,6 +35,7 @@ def test_xref_potential_conflicts(
     resolver: Resolver[CompositeEntity],
     capsys,
 ):
+    resolver.begin()
     store = SimpleMemoryStore(test_dataset, resolver)
     a = CompositeEntity.from_data(
         test_dataset,

--- a/tests/test_xref.py
+++ b/tests/test_xref.py
@@ -12,11 +12,11 @@ from nomenklatura.xref import xref
 
 
 def test_xref_candidates(
-    index_path: Path, dresolver: Resolver[CompositeEntity], dstore: SimpleMemoryStore
+    index_path: Path, resolver: Resolver[CompositeEntity], dstore: SimpleMemoryStore
 ):
-    xref(dresolver, dstore, index_path)
+    xref(resolver, dstore, index_path)
     view = dstore.default_view(external=True)
-    candidates = list(dresolver.get_candidates(limit=20))
+    candidates = list(resolver.get_candidates(limit=20))
     assert len(candidates) == 20
     for left_id, right_id, score in candidates:
         left = view.get_entity(left_id)
@@ -32,9 +32,9 @@ def test_xref_candidates(
 def test_xref_potential_conflicts(
     index_path: Path,
     test_dataset: Dataset,
+    resolver: Resolver[CompositeEntity],
     capsys,
 ):
-    resolver = Resolver[CompositeEntity]()
     store = SimpleMemoryStore(test_dataset, resolver)
     a = CompositeEntity.from_data(
         test_dataset,


### PR DESCRIPTION
- Replace JSON-file-based persistence with a database
- Exposes transaction management to caller as resolver state rather than passing a connection to the resolver so that store is unaware of resolver/linker implementation details
  - dedupe can commit after each edit to keep transaction short and low risk
  - xref can build store and manage candidates in one transaction
- Adds history log and edge editing to dedupe UI so that committed mistakes can be undone

nomenklatura side of https://github.com/opensanctions/opensanctions/issues/1810

- [x] postgres recursive query not happy
- [x] configurable table name test
- [x] decide between load using decide or _register

Before any edits

![image](https://github.com/user-attachments/assets/950aa64d-4343-4022-a551-cfe19876babe)

---

After two merges

![image](https://github.com/user-attachments/assets/c5ffec2a-1fed-4b40-904a-855d57f163a1)

---

Undoing a merge - changing the edge to NO_DECISION

![image](https://github.com/user-attachments/assets/548456cb-4744-4358-b38c-07e1ed8a9a03)

---

Changing a POSITIVE to UNSURE

![image](https://github.com/user-attachments/assets/33c6a172-c7d5-44bf-a7a3-e0dfeb76dcc0)
