### PR TITLE
Allow optimisation for read or write to be toggled

### DIFF
--- a/nomenklatura/cli.py
+++ b/nomenklatura/cli.py
@@ -74,7 +74,6 @@ def xref_file(
 ) -> None:
     resolver = Resolver[Entity].make_default()
     resolver.begin()
-    resolver.warm_linker()
     store = load_entity_file_store(path, resolver=resolver)
     algorithm_type = get_algorithm(algorithm)
     if algorithm_type is None:
@@ -152,13 +151,13 @@ def make_sortable(path: Path, outpath: Path) -> None:
 def dedupe(path: Path, xref: bool = False) -> None:
     resolver = Resolver[Entity].make_default()
     resolver.begin()
-    resolver.warm_linker()
     store = load_entity_file_store(path, resolver=resolver)
     if xref:
         index_dir = path.parent / INDEX_SEGMENT
         run_xref(resolver, store, index_dir)
     resolver.commit()
 
+    resolver.set_prioritise_read(False)
     dedupe_ui(resolver, store)
 
 

--- a/nomenklatura/cli.py
+++ b/nomenklatura/cli.py
@@ -282,7 +282,7 @@ def statements_aggregate(
 @cli.command("load-resolver", help="Load resolver edges from file into database")
 @click.argument("source", type=InPath)
 def load_resolver(source: Path) -> None:
-    resolver = Resolver[Entity].make_default()
+    resolver = Resolver[Entity].make_default(prioritise_read=False)
     resolver.begin()
     resolver.load(source)
     resolver.commit()

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -17,7 +17,7 @@
 import getpass
 import logging
 from functools import lru_cache
-from typing import Dict, Generator, Optional, Set, Tuple
+from typing import Any, Dict, Generator, Optional, Set, Tuple
 
 from followthemoney.types import registry
 from rigour.ids.wikidata import is_qid
@@ -78,7 +78,7 @@ class Resolver(Linker[CE]):
         self._linker: Optional[Linker[CE]] = None
         """A cached linker for bulk operations."""
 
-        unique_kw = {"unique": True}
+        unique_kw: Dict[str, Any] = {"unique": True}
         if engine.dialect.name == "sqlite":
             unique_kw["sqlite_where"] = text("deleted_at IS NULL")
         if engine.dialect.name in ("postgresql", "postgres"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ def donations_json(donations_path):
 
 @pytest.fixture(scope="function")
 def resolver():
-    resolver = Resolver[CompositeEntity].make_default()
+    resolver = Resolver[CompositeEntity].make_default(prioritise_read=False)
     yield resolver
     resolver.rollback(force=True)
     resolver._table.drop(resolver._engine)
@@ -73,7 +73,13 @@ def resolver():
 def other_table_resolver():
     engine = get_engine()
     meta = MetaData()
-    resolver = Resolver(engine, meta, create=True, table_name="another_table")
+    resolver = Resolver(
+        engine,
+        meta,
+        create=True,
+        table_name="another_table",
+        prioritise_read=False,
+    )
     yield resolver
     resolver.rollback(force=True)
     resolver._table.drop(engine)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -185,13 +185,16 @@ def test_cached_linker(resolver):
     assert resolver.get_canonical("a1") == canon_a
 
     assert resolver._linker is None
-    resolver.warm_linker()
+    resolver.set_prioritise_read(True)
     assert resolver._linker is not None
+    first_linker = resolver._linker
     # We get the same result as pre-warm
     assert resolver.get_canonical("a1") == canon_a
 
     canon_b = resolver.decide("b1", "b2", Judgement.POSITIVE)
-    assert resolver._linker is None  # cache is cleared
+    assert resolver._linker is not None
+    second_linker = resolver._linker
+    assert id(first_linker) != id(second_linker)  # cached linker updated.
     assert resolver.get_canonical("a1") == canon_a
     # New decision is available
     assert resolver.get_canonical("b1") == canon_b


### PR DESCRIPTION
With this, an xref run on sanctions after the store is build takes 26 minutes (macbook, local postgres)

This might be better than implementing stateless check_candidate() and decide() for a web-dedupe API.

