### PR TITLE
Maintain an in-memory node and edge set, write to db

### DIFF
--- a/nomenklatura/cli.py
+++ b/nomenklatura/cli.py
@@ -74,7 +74,6 @@ def xref_file(
 ) -> None:
     resolver = Resolver[Entity].make_default()
     resolver.begin()
-    resolver.warm_linker()
     store = load_entity_file_store(path, resolver=resolver)
     algorithm_type = get_algorithm(algorithm)
     if algorithm_type is None:
@@ -152,7 +151,6 @@ def make_sortable(path: Path, outpath: Path) -> None:
 def dedupe(path: Path, xref: bool = False) -> None:
     resolver = Resolver[Entity].make_default()
     resolver.begin()
-    resolver.warm_linker()
     store = load_entity_file_store(path, resolver=resolver)
     if xref:
         index_dir = path.parent / INDEX_SEGMENT

--- a/nomenklatura/resolver/linker.py
+++ b/nomenklatura/resolver/linker.py
@@ -13,6 +13,10 @@ class Linker(Generic[CE]):
     post de-duplication."""
 
     def __init__(self, entities: Dict[Identifier, Set[Identifier]] = {}) -> None:
+        """
+        Args:
+            entities: an entry for each entity with its connected set of entities.
+        """
         self._entities: Dict[Identifier, Set[Identifier]] = entities
 
     def connected(self, node: Identifier) -> Set[Identifier]:

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -61,9 +61,9 @@ class Resolver(Linker[CE]):
 
         unique_kw: Dict[str, Any] = {"unique": True}
         if engine.dialect.name == "sqlite":
-            unique_kw["sqlite_where"] = text("deleted_at IS NOT NULL")
+            unique_kw["sqlite_where"] = text("deleted_at IS NULL")
         if engine.dialect.name in ("postgresql", "postgres"):
-            unique_kw["postgresql_where"] = text("deleted_at IS NOT NULL")
+            unique_kw["postgresql_where"] = text("deleted_at IS NULL")
         unique_pair = Index(
             f"{table_name}_source_target_uniq",
             text("source"),

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -117,6 +117,7 @@ class Resolver(Linker[CE]):
         # Apply the new edges that currently exist (not deleted yet)
         stmt = self._table.select()
         stmt = stmt.where(self._table.c.deleted_at.is_(None))
+        stmt = stmt.where(self._table.c.id > self._max_id)
         cursor = self._get_connection().execute(stmt)
         while batch := cursor.fetchmany(10000):
             for row in batch:

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -107,10 +107,11 @@ class Resolver(Linker[CE]):
                 edge = Edge.from_dict(row._mapping)
                 if self._max_ts is None:
                     self._max_ts = edge.created_at
-                else:
-                    self._max_ts = max(self._max_ts, edge.created_at)
-                if edge.deleted_at is not None:
-                    self._max_ts = max(self._max_ts, edge.deleted_at)
+                if self._max_ts is not None:
+                    if edge.created_at is not None:
+                        self._max_ts = max(self._max_ts, edge.created_at)
+                    if edge.deleted_at is not None:
+                        self._max_ts = max(self._max_ts, edge.deleted_at)
                 self._update_edge(edge)
         cursor.close()
 

--- a/nomenklatura/settings.py
+++ b/nomenklatura/settings.py
@@ -4,9 +4,10 @@ from rigour.env import env_str, env_int
 TESTING = False
 
 DB_PATH = Path("nomenklatura.db").resolve()
+DEFAULT_DB_URL = f"sqlite:///{DB_PATH.as_posix()}"
 DB_URL = env_str("NOMENKLATURA_DB_URL", "")
 if DB_URL is None or not len(DB_URL):
-    DB_URL = f"sqlite:///{DB_PATH.as_posix()}"
+    DB_URL = DEFAULT_DB_URL
 DB_POOL_SIZE = env_int("NOMENKLATURA_DB_POOL_SIZE", 5)
 DB_STMT_TIMEOUT = env_int("NOMENKLATURA_DB_STMT_TIMEOUT", 10000)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,7 @@ def resolver():
     resolver = Resolver[CompositeEntity].make_default()
     yield resolver
     resolver.rollback(force=True)
-    resolver._table.drop(resolver._engine)
+    resolver._table.drop(resolver._engine, checkfirst=True)
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -198,13 +198,6 @@ def test_update_from_db(resolver):
         r1.begin()
         r2.begin()
         assert set(r1.canonicals()) == set()
-        r1.suggest("a1", "a2", 1.0, "test user")
-        r2.suggest("b1", "b2", 1.0, "test user")
-        r1.commit()
-        r2.commit()
-
-        r1.begin()
-        r2.begin()
         canon_a = r1.decide("a1", "a2", Judgement.POSITIVE, user="r1")
         canon_b = r2.decide("b1", "b2", Judgement.POSITIVE, user="r2")
         assert set(r1.canonicals()) == {canon_a}
@@ -223,9 +216,6 @@ def test_update_from_db(resolver):
         assert Identifier.get("b2") in r2.connected(canon_b)
         r1.remove("b2")
         r2.remove("a2")
-        # TODO: postgres locks when these are happening in concurrent transactions
-        # r1.decide(canon_a, "a3", Judgement.POSITIVE, user="r1")
-        # r2.decide(canon_a, "a3", Judgement.UNSURE, user="r2")
         r1.commit()
         r2.commit()
 
@@ -234,9 +224,6 @@ def test_update_from_db(resolver):
         # They see each others' deletes
         assert Identifier.get("a2") not in r1.connected(canon_a)
         assert Identifier.get("b2") not in r2.connected(canon_b)
-        # TODO: what determines which one wins?
-        # assert r1.get_judgement(canon_a, "a3") == Judgement.UNSURE
-        # assert r2.get_judgement(canon_a, "a3") == Judgement.UNSURE
         r1.commit()
         r2.commit()
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -159,8 +159,8 @@ def test_linker(resolver):
     canon_b = resolver.decide("b1", "b2", Judgement.POSITIVE)
     resolver.decide("a1", "Q123", Judgement.POSITIVE)
     resolver.decide("a2", "c2", Judgement.NEGATIVE)
-    linker = resolver.get_linker()
     resolver.commit()
+    linker = resolver.get_linker()
 
     assert len(linker.connected(canon_a)) == 4
     assert len(linker.connected(canon_b)) == 3
@@ -169,7 +169,7 @@ def test_linker(resolver):
     #   Q123 canon_a a1 a2 # removed a3
     #   canon_b b1 b2
     #   c2
-    assert len(linker._entities) == 8, linker._entities
+    assert len(linker._entities) == 7, linker._entities
     assert "a1" in linker.get_referents("Q123")
     assert "a2" in linker.get_referents("Q123")
     assert canon_a.id in linker.get_referents("Q123")


### PR DESCRIPTION
fetch other instances' updates from db at transaction start

This is for fast reads and writes, only loading full resolver once.

Also requires the migration

```sql
CREATE UNIQUE INDEX resolver_source_target_uniq ON resolver(source, target) WHERE deleted_at IS NOT NULL
```