### PR TITLE
Document which properties are used by each feature

### DIFF
--- a/nomenklatura/matching/compare/names.py
+++ b/nomenklatura/matching/compare/names.py
@@ -3,6 +3,7 @@ from itertools import product
 from followthemoney.proxy import E
 from followthemoney.types import registry
 from fingerprints import clean_name_light, clean_name_ascii
+from nomenklatura.matching.types import CompareFunction
 from rigour.text.distance import levenshtein_similarity
 from rigour.text.distance import jaro_winkler, is_levenshtein_plausible
 from nomenklatura.util import names_word_list, name_words
@@ -113,12 +114,16 @@ def name_fingerprint_levenshtein(query: E, result: E) -> float:
     return max_score
 
 
-def name_literal_match(query: E, result: E) -> float:
+class NameLiteralMatch(CompareFunction):
     """Two entities have the same name, without normalization applied to the name."""
-    query_names, result_names = type_pair(query, result, registry.name)
-    qnames = clean_map(query_names, clean_name_light)
-    rnames = clean_map(result_names, clean_name_light)
-    return 1.0 if has_overlap(qnames, rnames) else 0.0
+
+    domain = "Properties of type `Thing:name`"
+
+    def __call__(self, query: E, result: E) -> float:
+        query_names, result_names = type_pair(query, result, registry.name)
+        qnames = clean_map(query_names, clean_name_light)
+        rnames = clean_map(result_names, clean_name_light)
+        return 1.0 if has_overlap(qnames, rnames) else 0.0
 
 
 def last_name_mismatch(query: E, result: E) -> float:

--- a/nomenklatura/matching/logic.py
+++ b/nomenklatura/matching/logic.py
@@ -4,15 +4,15 @@ from nomenklatura.matching.types import Feature, HeuristicAlgorithm
 from nomenklatura.matching.compare.countries import country_mismatch
 from nomenklatura.matching.compare.gender import gender_mismatch
 from nomenklatura.matching.compare.identifiers import orgid_disjoint
-from nomenklatura.matching.compare.identifiers import crypto_wallet_address
+from nomenklatura.matching.compare.identifiers import CryptoWalletAddress
 from nomenklatura.matching.compare.identifiers import bic_code_match
 from nomenklatura.matching.compare.identifiers import inn_code_match, ogrn_code_match
 from nomenklatura.matching.compare.identifiers import lei_code_match, identifier_match
 from nomenklatura.matching.compare.identifiers import isin_security_match
-from nomenklatura.matching.compare.identifiers import vessel_imo_mmsi_match
+from nomenklatura.matching.compare.identifiers import VesselIMO_MMSIMatch
 from nomenklatura.matching.compare.dates import dob_day_disjoint, dob_year_disjoint
 from nomenklatura.matching.compare.names import person_name_jaro_winkler
-from nomenklatura.matching.compare.names import last_name_mismatch, name_literal_match
+from nomenklatura.matching.compare.names import last_name_mismatch, NameLiteralMatch
 from nomenklatura.matching.compare.names import name_fingerprint_levenshtein
 from nomenklatura.matching.compare.names import weak_alias_match
 from nomenklatura.matching.compare.phonetic import person_name_phonetic_match
@@ -30,7 +30,7 @@ class LogicV1(HeuristicAlgorithm):
 
     NAME = "logic-v1"
     features = [
-        Feature(func=name_literal_match, weight=1.0),
+        Feature(func=NameLiteralMatch(), weight=1.0),
         Feature(func=person_name_jaro_winkler, weight=0.8),
         Feature(func=person_name_phonetic_match, weight=0.9),
         Feature(func=name_fingerprint_levenshtein, weight=0.9),
@@ -38,11 +38,11 @@ class LogicV1(HeuristicAlgorithm):
         Feature(func=name_metaphone_match, weight=FNUL),
         Feature(func=name_soundex_match, weight=FNUL),
         Feature(func=address_entity_match, weight=0.98),
-        Feature(func=crypto_wallet_address, weight=0.98),
+        Feature(func=CryptoWalletAddress(), weight=0.98),
         Feature(func=isin_security_match, weight=0.98),
         Feature(func=lei_code_match, weight=0.95),
         Feature(func=ogrn_code_match, weight=0.95),
-        Feature(func=vessel_imo_mmsi_match, weight=0.95),
+        Feature(func=VesselIMO_MMSIMatch(), weight=0.95),
         Feature(func=inn_code_match, weight=0.95),
         Feature(func=bic_code_match, weight=0.95),
         Feature(func=identifier_match, weight=0.85),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pydantic > 2.0.0, < 3.0.0",
     "click < 9.0.0",
     "lxml > 4.0.0, < 6.0.0",
+    "camel-converter",
 ]
 
 [project.urls]


### PR DESCRIPTION
Users sometimes aren't sure which properties are actually used by the matcher. I think part of the the issue is that some features apply to all properties of a given type, while some only apply to properties with a given name. That's not clear from the description. That could be added to the description, but it might be more readable if kept as a separate field.

It could be presented like this:

![image](https://github.com/user-attachments/assets/174af943-700d-40d3-b0eb-3f5bfc670d37)
