### PR TITLE
logic_v2: Don't set matched family name weight on unmatched

### DIFF
--- a/nomenklatura/matching/logic_v2/names/match.py
+++ b/nomenklatura/matching/logic_v2/names/match.py
@@ -88,12 +88,11 @@ def match_name_symbolic(query: Name, result: Name, config: ScoringConfig) -> FtR
             if len(match.qps) == 0:
                 bias = weight_extra_match(match.rps, result)
                 match.weight = extra_result_weight * bias
-                continue
             # unmatched query part
             elif len(match.rps) == 0:
                 bias = weight_extra_match(match.qps, query)
                 match.weight = extra_query_weight * bias
-                continue
+            # We fall through here to apply the family-name boost to unmatched parts too.
 
             # We have types of symbol matches and where we never score 1.0, but for
             # literal matches, we always want to score 1.0


### PR DESCRIPTION
Previously, we would score an unmatched family name in the result or the query as weight 1.3, equal to a matched family name. We now apply the same weighting as for other unmatched names.
