### PR TITLE
Issue #266 Fix: [regression_v1] name_match not returning binary values

### DIFF
--- a/nomenklatura/matching/regression_v1/names.py
+++ b/nomenklatura/matching/regression_v1/names.py
@@ -42,11 +42,8 @@ def name_match(left: E, right: E) -> float:
     """Check for exact name matches between the two entities."""
     lv, rv = type_pair(left, right, registry.name)
     lvn, rvn = normalize_names(lv), normalize_names(rv)
-    common = [len(n) for n in lvn.intersection(rvn)]
-    max_common = max(common, default=0)
-    if max_common == 0:
-        return 0.0
-    return float(max_common)
+    common = lvn.intersection(rvn)
+    return 1.0 if len(common) > 0 else 0.0
 
 
 def name_token_overlap(left: E, right: E) -> float:


### PR DESCRIPTION
The name_match() function in regression_v1/names.py was incorrectly returning the character length of the longest matching name instead of a boolean value indicating whether an exact match exists.

**Current Function:**
```
def name_match(left: Set[str], right: Set[str]) -> float:
    """Current implementation - returns character length"""
    lvn = normalize_names(left)
    rvn = normalize_names(right)
    common = [len(n) for n in lvn.intersection(rvn)]
    max_common = max(common, default=0)
    if max_common == 0:
        return 0.0
    return float(max_common)
```

**Fixed Function:**
```
def name_match(left: Set[str], right: Set[str]) -> float:
    """Proposed fix - returns boolean 1.0 or 0.0"""
    lvn = normalize_names(left)
    rvn = normalize_names(right)
    common = lvn.intersection(rvn)
    return 1.0 if len(common) > 0 else 0.0

  ```

Before:
- "John Doe" exact match → returned 8.0 (character count)
- "Jane Smith" exact match → returned 10.0 (character count)

After:
- Any exact match → returns 1.0
- No exact match → returns 0.0

Examples:

```
Test 1: Match (John Doe)
  old version:  8.0
  new version:  1.0

Test 2: Match (Jane Smith)
  old version:  10.0
  new version:  1.0

Test 3: No match (John Doe, Jane Smith)
  old version:  0.0
  new version:  0.0
```