### PR TITLE
Fetch Wikipedia URLs as part of the API

### DIFF
--- a/nomenklatura/wikidata/client.py
+++ b/nomenklatura/wikidata/client.py
@@ -41,10 +41,23 @@ class WikidataClient(object):
     def fetch_item(self, qid: str, cache_days: Optional[int] = None) -> Optional[Item]:
         # https://www.mediawiki.org/wiki/Wikibase/API
         # https://www.wikidata.org/w/api.php?action=help&modules=wbgetentities
-        params = {"format": "json", "ids": qid, "action": "wbgetentities"}
-        url = build_url(self.WD_API, params=params)
         cache_days = cache_days or self.cache_days
-        raw = self.cache.get(url, max_age=cache_days)
+        old_params = {"format": "json", "ids": qid, "action": "wbgetentities"}
+        old_url = build_url(self.WD_API, params=old_params)
+        raw = self.cache.get(old_url, max_age=cache_days)
+        # Ask for sitelink URLs:
+        params = {
+            "format": "json",
+            "ids": qid,
+            "action": "wbgetentities",
+            "props": "info|sitelinks/urls|aliases|labels|descriptions|claims|datatype",
+        }
+        url = build_url(self.WD_API, params=params)
+
+        # FIXME: remove this once the cache has run out, this is just to migrate old
+        # cache keys to new ones. Estimated: mid-April 2026.
+        if raw is None:
+            raw = self.cache.get(url, max_age=cache_days)
         if raw is None:
             res = self.session.get(url)
             res.raise_for_status()

--- a/nomenklatura/wikidata/model.py
+++ b/nomenklatura/wikidata/model.py
@@ -1,6 +1,7 @@
 from urllib.parse import quote
 from normality import stringify
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
+from rigour.langs import iso_639_alpha3
 
 from nomenklatura.wikidata.value import snak_value_to_string
 from nomenklatura.wikidata.lang import LangText
@@ -88,14 +89,30 @@ class SiteLink(object):
         self.qid = qid
         self.site = data.pop("site")
         self.is_wiki = self.site.endswith("wiki")
+        self.wiki_site = self.site[:-4] if self.is_wiki else None
         self.title = data.pop("title")
         self.badges = data.pop("badges", [])
+        self._url = str(data.pop("url")) if "url" in data else None
+
+    # TODO: remove this entirely once the cache has run out, make `_url` the prop.
+    @property
+    def url(self) -> Optional[str]:
+        if self._url is not None:
+            return str(self._url)
+        # FIXME: this is broken because it does not convert site key to domain:
+        # enwiki -> en.wikipedia.org. We should remove this and make sure the API
+        # returns the URL.
+        if self.is_wiki is False:
+            return None
+        domain = f"{self.site}.wikipedia.org"
+        quoted = quote(self.title.replace(" ", "_"), safe="/_-")
+        return f"https://{domain}/wiki/{quoted}"
 
     @property
-    def url(self) -> str:
-        # quoted = quote(self.title.replace(" ", "_"), safe="/:@!$&'()*+,;=-._~")
-        quoted = quote(self.title.replace(" ", "_"), safe="/_-")
-        return f"https://{self.site}.wikipedia.org/wiki/{quoted}"
+    def lang(self) -> Optional[str]:
+        if self.wiki_site is not None:
+            return iso_639_alpha3(self.wiki_site)
+        return None
 
     @property
     def linked_url(self) -> str:


### PR DESCRIPTION
This fixes https://github.com/opensanctions/opensanctions/issues/3820 by backfilling the Wikipedia URLs from the Wikidata API. Right now the `wikidata` dataset in OpenSanctions is set for 14 days cache, which would spread the delta out over just a few days - but we could push this to 20 or 25 days to make it properly spaced out?