### PR TITLE
Remove the bad sitelinks cache entry once we decide it's invalidated

### DIFF
--- a/nomenklatura/wikidata/client.py
+++ b/nomenklatura/wikidata/client.py
@@ -57,6 +57,7 @@ class WikidataClient(object):
         # FIXME: remove this once the cache has run out, this is just to migrate old
         # cache keys to new ones. Estimated: mid-April 2026.
         if raw is None:
+            self.cache.delete(old_url)  # Make sure we don't use the old value again
             raw = self.cache.get(url, max_age=cache_days)
         if raw is None:
             res = self.session.get(url)


### PR DESCRIPTION
While the old wikidata item URL is within the randomised expiry window (10-26 days for a 20 day cache_days, we might randomly consider it valid still, resulting in flip-flopping between correct and incorrect sitelinks values, resulting in massive daily deltas.

https://github.com/opensanctions/opensanctions/issues/3820#issuecomment-4223161145

This removes the bad value from the cache the moment we decide it's invalid so we never use it again.
