### PR TITLE
skip wikimedia commons URLs, drop gradual fix of wikipedia URLs

### DIFF
--- a/nomenklatura/db.py
+++ b/nomenklatura/db.py
@@ -9,14 +9,13 @@ from sqlalchemy import (
     Boolean,
     Column,
     DateTime,
-    Dialect,
     MetaData,
     Table,
     Unicode,
     create_engine,
     delete,
 )
-from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.engine import Connection, Dialect, Engine
 from sqlalchemy.dialects.postgresql import insert as psql_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 

--- a/nomenklatura/enrich/aleph.py
+++ b/nomenklatura/enrich/aleph.py
@@ -79,7 +79,7 @@ class AlephEnricher(Enricher[DS]):
         for _, values in properties.items():
             for value in ensure_list(values):
                 if is_mapping(value):
-                    proxy = self.load_aleph_entity(entity, value)
+                    proxy = self.load_aleph_entity(entity, dict(value))
                     if proxy is not None:
                         yield proxy
 

--- a/nomenklatura/enrich/wikidata.py
+++ b/nomenklatura/enrich/wikidata.py
@@ -285,18 +285,10 @@ class WikidataEnricher(Enricher[DS]):
             value.apply(proxy, ftm_prop)
 
         # See https://github.com/opensanctions/opensanctions/issues/3651
-        # First preference is enwiki
         for wikilink in item.wikilinks:
             if wikilink.site == "enwiki":
                 proxy.add("wikipediaUrl", wikilink.url, origin=wikilink.title)
                 break
-        # Second preference is commonswiki
-        if not proxy.has("wikipediaUrl"):
-            for wikilink in item.wikilinks:
-                if wikilink.site == "commonswiki":
-                    proxy.add("wikipediaUrl", wikilink.url, origin=wikilink.title)
-                    break
-        # Final preference is any other wiki.
         # We only use this if there are very few, since what we pick is then potentially significant for them.
         if not proxy.has("wikipediaUrl"):
             if len(item.wikilinks) < 3:

--- a/nomenklatura/enrich/wikidata.py
+++ b/nomenklatura/enrich/wikidata.py
@@ -290,12 +290,11 @@ class WikidataEnricher(Enricher[DS]):
                 proxy.add("wikipediaUrl", wikilink.url, origin=wikilink.title)
                 break
         # We only use this if there are very few, since what we pick is then potentially significant for them.
-        if not proxy.has("wikipediaUrl"):
-            if len(item.wikilinks) < 3:
-                # Sort to be sure we pick the same link consistently
-                for wikilink in sorted(item.wikilinks, key=lambda s: s.site):
-                    proxy.add("wikipediaUrl", wikilink.url, origin=wikilink.title)
-                    break
+        if not proxy.has("wikipediaUrl") and len(item.wikilinks) < 3:
+            # Sort to be sure we pick the same link consistently
+            for wikilink in sorted(item.wikilinks, key=lambda s: s.site):
+                proxy.add("wikipediaUrl", wikilink.url, origin=wikilink.title)
+                break
         # TODO: do we want to do more sophisticated handling of wikilinks? For
         # example, if there are no English links, but there are many in other
         # languages, then maybe we should still include the first one?

--- a/nomenklatura/enrich/wikidata.py
+++ b/nomenklatura/enrich/wikidata.py
@@ -285,14 +285,25 @@ class WikidataEnricher(Enricher[DS]):
             value.apply(proxy, ftm_prop)
 
         # See https://github.com/opensanctions/opensanctions/issues/3651
+        # First preference is enwiki
         for wikilink in item.wikilinks:
             if wikilink.site == "enwiki":
                 proxy.add("wikipediaUrl", wikilink.url, origin=wikilink.title)
                 break
-        if not proxy.has("wikipediaUrl") and len(item.wikilinks) < 3:
+        # Second preference is commonswiki
+        if not proxy.has("wikipediaUrl"):
             for wikilink in item.wikilinks:
-                proxy.add("wikipediaUrl", wikilink.url, origin=wikilink.title)
-                break
+                if wikilink.site == "commonswiki":
+                    proxy.add("wikipediaUrl", wikilink.url, origin=wikilink.title)
+                    break
+        # Final preference is any other wiki.
+        # We only use this if there are very few, since what we pick is then potentially significant for them.
+        if not proxy.has("wikipediaUrl"):
+            if len(item.wikilinks) < 3:
+                # Sort to be sure we pick the same link consistently
+                for wikilink in sorted(item.wikilinks, key=lambda s: s.site):
+                    proxy.add("wikipediaUrl", wikilink.url, origin=wikilink.title)
+                    break
         # TODO: do we want to do more sophisticated handling of wikilinks? For
         # example, if there are no English links, but there are many in other
         # languages, then maybe we should still include the first one?

--- a/nomenklatura/wikidata/client.py
+++ b/nomenklatura/wikidata/client.py
@@ -41,24 +41,16 @@ class WikidataClient(object):
     def fetch_item(self, qid: str, cache_days: Optional[int] = None) -> Optional[Item]:
         # https://www.mediawiki.org/wiki/Wikibase/API
         # https://www.wikidata.org/w/api.php?action=help&modules=wbgetentities
-        cache_days = cache_days or self.cache_days
-        old_params = {"format": "json", "ids": qid, "action": "wbgetentities"}
-        old_url = build_url(self.WD_API, params=old_params)
-        raw = self.cache.get(old_url, max_age=cache_days)
-        # Ask for sitelink URLs:
         params = {
             "format": "json",
             "ids": qid,
             "action": "wbgetentities",
+            # Ask for sitelink URLs for proper wikipedia links:
             "props": "info|sitelinks/urls|aliases|labels|descriptions|claims|datatype",
         }
         url = build_url(self.WD_API, params=params)
-
-        # FIXME: remove this once the cache has run out, this is just to migrate old
-        # cache keys to new ones. Estimated: mid-April 2026.
-        if raw is None:
-            self.cache.delete(old_url)  # Make sure we don't use the old value again
-            raw = self.cache.get(url, max_age=cache_days)
+        cache_days = cache_days or self.cache_days
+        raw = self.cache.get(url, max_age=cache_days)
         if raw is None:
             res = self.session.get(url)
             res.raise_for_status()

--- a/nomenklatura/wikidata/model.py
+++ b/nomenklatura/wikidata/model.py
@@ -1,4 +1,3 @@
-from urllib.parse import quote
 from normality import stringify
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 from rigour.langs import iso_639_alpha3
@@ -92,21 +91,7 @@ class SiteLink(object):
         self.wiki_site = self.site[:-4] if self.is_wiki else None
         self.title = data.pop("title")
         self.badges = data.pop("badges", [])
-        self._url = str(data.pop("url")) if "url" in data else None
-
-    # TODO: remove this entirely once the cache has run out, make `_url` the prop.
-    @property
-    def url(self) -> Optional[str]:
-        if self._url is not None:
-            return str(self._url)
-        # FIXME: this is broken because it does not convert site key to domain:
-        # enwiki -> en.wikipedia.org. We should remove this and make sure the API
-        # returns the URL.
-        if self.is_wiki is False:
-            return None
-        domain = f"{self.site}.wikipedia.org"
-        quoted = quote(self.title.replace(" ", "_"), safe="/_-")
-        return f"https://{domain}/wiki/{quoted}"
+        self.url = str(data.pop("url")) if "url" in data else None
 
     @property
     def lang(self) -> Optional[str]:
@@ -166,8 +151,9 @@ class Item(object):
 
     @property
     def wikilinks(self) -> List[SiteLink]:
+        wikilinks = [s for s in self.sitelinks if s.is_wiki]
         # Skip commonswiki since it doesn't offer much more than wikidata as a wiki website.
-        return [s for s in self.sitelinks if s.is_wiki and s.site != "commonswiki"]
+        return [s for s in wikilinks if s.site != "commonswiki"]
 
     def is_instance(self, qid: str) -> bool:
         for claim in self.claims:

--- a/nomenklatura/wikidata/model.py
+++ b/nomenklatura/wikidata/model.py
@@ -166,7 +166,8 @@ class Item(object):
 
     @property
     def wikilinks(self) -> List[SiteLink]:
-        return [s for s in self.sitelinks if s.is_wiki]
+        # Skip commonswiki since it doesn't offer much more than wikidata as a wiki website.
+        return [s for s in self.sitelinks if s.is_wiki and s.site != "commonswiki"]
 
     def is_instance(self, qid: str) -> bool:
         for claim in self.claims:


### PR DESCRIPTION
- skip wikimedia commons links https://github.com/opensanctions/opensanctions/issues/3820#issuecomment-4243471930
- don't assume ordered JSON (just in case) https://github.com/opensanctions/opensanctions/issues/3820#issuecomment-4225133912
- revert gradual fix so that the net client diff looks like
```diff
  $ git diff e3f3e4c83294f14b74ceba9a6669d7404b704952 nomenklatura/wikidata/client.py
diff --git a/nomenklatura/wikidata/client.py b/nomenklatura/wikidata/client.py
index 52096c0..a0e2545 100644
--- a/nomenklatura/wikidata/client.py
+++ b/nomenklatura/wikidata/client.py
@@ -41,7 +41,13 @@ class WikidataClient(object):
     def fetch_item(self, qid: str, cache_days: Optional[int] = None) -> Optional[Item]:
         # https://www.mediawiki.org/wiki/Wikibase/API
         # https://www.wikidata.org/w/api.php?action=help&modules=wbgetentities
-        params = {"format": "json", "ids": qid, "action": "wbgetentities"}
+        params = {
+            "format": "json",
+            "ids": qid,
+            "action": "wbgetentities",
+            # Ask for sitelink URLs for proper wikipedia links:
+            "props": "info|sitelinks/urls|aliases|labels|descriptions|claims|datatype",
+        }
         url = build_url(self.WD_API, params=params)
         cache_days = cache_days or self.cache_days
         raw = self.cache.get(url, max_age=cache_days)
```