### PR TITLE
[brightquery] handle API timeouts without crashing the enrichment run

### DIFF
--- a/nomenklatura/enrich/brightquery.py
+++ b/nomenklatura/enrich/brightquery.py
@@ -117,7 +117,15 @@ class BrightQueryEnricher(Enricher[DS]):
         resp_data = self.cache.get_json(cache_key, max_age=self.cache_days)
         if not resp_data:
             log.info("BrightQuery search: %r", payload)
-            response = self.session.post(self.BASE_URL, json=payload, timeout=15)
+            try:
+                response = self.session.post(
+                    self.BASE_URL,
+                    json=payload,
+                    timeout=(10, 60),
+                )
+            except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
+                log.error("BrightQuery connection failed for %r: %s", payload, exc)
+                return
             # When no results are found, the API helpfully doesn't return JSON
             # but just a 204 with an empty response body.
             if response.status_code == 204:


### PR DESCRIPTION
Increase the read timeout from 15s to 60s (keeping a 10s connect timeout) to give the BrightQuery API enough headroom for slow responses. When the API is unreachable or all retries are exhausted, catch both ConnectionError (MaxRetryError wrapping ReadTimeoutError) and Timeout (bare ReadTimeout / ConnectTimeout) and log an error rather than letting the exception propagate and kill the entire run.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>