### PR TITLE
Introduce nomenklatura.db.Session; make Cache and Resolver session consumers

### DIFF
--- a/nomenklatura/cache.py
+++ b/nomenklatura/cache.py
@@ -7,15 +7,13 @@ from typing import Any, cast, Dict, Optional, Union, Generator
 from datetime import datetime, timedelta
 from sqlalchemy import MetaData
 from sqlalchemy import Table, Column, DateTime, Unicode
-from sqlalchemy.engine import Engine, Connection, Transaction
 from sqlalchemy.future import select
 from sqlalchemy.sql.expression import delete
-from sqlalchemy.exc import OperationalError, InvalidRequestError
 from sqlalchemy.dialects.postgresql import insert as upsert
 from rigour.time import naive_now
 from followthemoney import Dataset
 
-from nomenklatura.db import get_engine, get_metadata
+from nomenklatura.db import Session
 
 
 log = logging.getLogger(__name__)
@@ -38,32 +36,22 @@ def randomize_cache(days: int) -> timedelta:
 
 class Cache(object):
     def __init__(
-        self, engine: Engine, metadata: MetaData, dataset: Dataset, create: bool = False
+        self, session: Session, dataset: Dataset, create: bool = False
     ) -> None:
         self.dataset = dataset
-        self._engine = engine
-        self._conn: Optional[Connection] = None
-        self._transaction: Optional[Transaction] = None
+        self._session = session
         self._table = Table(
             "cache",
-            metadata,
+            MetaData(),
             Column("key", Unicode(), primary_key=True),
             Column("text", Unicode(), nullable=True),
             Column("dataset", Unicode(), nullable=False),
             Column("timestamp", DateTime, index=True),
-            extend_existing=True,
         )
         if create:
-            metadata.create_all(bind=engine, checkfirst=True, tables=[self._table])
+            session.create(self._table)
 
         self._preload: Dict[str, CacheValue] = {}
-
-    @property
-    def conn(self) -> Connection:
-        if self._conn is None:
-            self._conn = self._engine.connect()
-            self._transaction = self._conn.begin()
-        return self._conn
 
     def set(self, key: str, value: Value) -> None:
         self._preload.pop(key, None)
@@ -73,18 +61,14 @@ class Cache(object):
             "dataset": self.dataset.name,
             "text": value,
         }
-        try:
-            istmt = upsert(self._table).values(cache)
-            values = dict(
-                timestamp=istmt.excluded.timestamp,
-                text=istmt.excluded.text,
-                dataset=istmt.excluded.dataset,
-            )
-            stmt = istmt.on_conflict_do_update(index_elements=["key"], set_=values)
-            self.conn.execute(stmt)
-        except (OperationalError, InvalidRequestError) as exc:
-            log.exception("Error while saving to cache: %s" % exc)
-            self.reset()
+        istmt = upsert(self._table).values(cache)
+        values = dict(
+            timestamp=istmt.excluded.timestamp,
+            text=istmt.excluded.text,
+            dataset=istmt.excluded.dataset,
+        )
+        stmt = istmt.on_conflict_do_update(index_elements=["key"], set_=values)
+        self._session.execute(stmt)
 
     def set_json(self, key: str, value: Any) -> None:
         return self.set(key, json.dumps(value))
@@ -109,13 +93,8 @@ class Cache(object):
             q = q.filter(self._table.c.timestamp > cache_cutoff)
         q = q.order_by(self._table.c.timestamp.desc())
         q = q.limit(1)
-        try:
-            result = self.conn.execute(q)
-            row = result.fetchone()
-        except InvalidRequestError as ire:
-            log.exception("Cache fetch error: %s", ire)
-            self.reset()
-            return None
+        result = self._session.execute(q)
+        row = result.fetchone()
         if row is not None:
             return cast(Optional[str], row.text)
         return None
@@ -133,19 +112,14 @@ class Cache(object):
         self._preload.pop(key, None)
         pq = delete(self._table)
         pq = pq.where(self._table.c.key == key)
-        try:
-            self.conn.execute(pq)
-        except InvalidRequestError as ire:
-            log.exception("Cache delete error: %s", ire)
-            self.reset()
-            return None
+        self._session.execute(pq)
 
     def all(self, like: Optional[str]) -> Generator[CacheValue, None, None]:
         q = select(self._table)
         if like is not None:
             q = q.filter(self._table.c.key.like(like))
 
-        result = self.conn.execute(q)
+        result = self._session.execute(q)
         for row in result.yield_per(10000):
             yield CacheValue(row.key, row.dataset, row.text, row.timestamp)
 
@@ -155,40 +129,12 @@ class Cache(object):
             self._preload[cache.key] = cache
 
     def clear(self) -> None:
-        try:
-            pq = delete(self._table)
-            pq = pq.where(self._table.c.dataset == self.dataset.name)
-            self.conn.execute(pq)
-        except InvalidRequestError:
-            log.exception("Cannot clear cache from database")
-            self.reset()
-
-    def reset(self) -> None:
-        if self._conn is not None:
-            self._conn.close()
-        self._conn = None
-        self._transaction = None
-
-    def flush(self) -> None:
-        # log.info("Flushing cache.")
-        if self._transaction is not None:
-            try:
-                self._transaction.commit()
-            except InvalidRequestError:
-                log.exception("Transaction was failed, cannot store cache state.")
-        self.reset()
-
-    def close(self) -> None:
-        self.flush()
+        pq = delete(self._table)
+        pq = pq.where(self._table.c.dataset == self.dataset.name)
+        self._session.execute(pq)
 
     def __repr__(self) -> str:
         return f"<Cache({self._table!r})>"
 
     def __hash__(self) -> int:
         return hash((self.dataset.name, self._table.name))
-
-    @classmethod
-    def make_default(cls, dataset: Dataset) -> "Cache":
-        engine = get_engine()
-        metadata = get_metadata()
-        return cls(engine, metadata, dataset, create=True)

--- a/nomenklatura/cli.py
+++ b/nomenklatura/cli.py
@@ -46,10 +46,8 @@ def _load_enricher(
 
 
 def _get_linker() -> Linker[Entity]:
-    resolver = Resolver[Entity].make_default()
-    linker = resolver.get_linker()
-    resolver.close()
-    return linker
+    with make_session() as session:
+        return Resolver[Entity](session, create=True).get_linker()
 
 
 def _get_data_path(data_path: Optional[Path]) -> Path:
@@ -96,32 +94,33 @@ def xref_file(
     focus: tuple[str, ...] = (),
     discount_internal: float = 1.0,
 ) -> None:
-    resolver = Resolver[Entity].make_default()
-    resolver.begin()
-    data_path = _get_data_path(data_path)
+    with make_session() as session:
+        resolver = Resolver[Entity](session, create=True)
+        resolver.load_into_memory()
+        data_path = _get_data_path(data_path)
 
-    store = load_entity_file_store(path, resolver=resolver)
-    algorithm_type = get_algorithm(algorithm)
-    if algorithm_type is None:
-        raise click.Abort(f"Unknown algorithm: {algorithm}")
+        store = load_entity_file_store(path, resolver=resolver)
+        algorithm_type = get_algorithm(algorithm)
+        if algorithm_type is None:
+            raise click.Abort(f"Unknown algorithm: {algorithm}")
 
-    index_dir = data_path / INDEX_SEGMENT
-    if clear and index_dir.exists():
-        log.info("Clearing index: %s", index_dir)
-        shutil.rmtree(index_dir, ignore_errors=True)
-    run_xref(
-        resolver,
-        store,
-        index_dir,
-        auto_threshold=auto_threshold,
-        algorithm=algorithm_type,
-        scored=scored,
-        limit=limit,
-        focus_datasets=set(focus),
-        discount_internal=discount_internal,
-    )
-    resolver.commit()
-    log.info("Xref complete in: %r", resolver)
+        index_dir = data_path / INDEX_SEGMENT
+        if clear and index_dir.exists():
+            log.info("Clearing index: %s", index_dir)
+            shutil.rmtree(index_dir, ignore_errors=True)
+        run_xref(
+            resolver,
+            session,
+            store,
+            index_dir,
+            auto_threshold=auto_threshold,
+            algorithm=algorithm_type,
+            scored=scored,
+            limit=limit,
+            focus_datasets=set(focus),
+            discount_internal=discount_internal,
+        )
+        log.info("Xref complete in: %r", resolver)
 
 
 @cli.command(
@@ -161,14 +160,14 @@ def wikidata_reconcile(
         # it only gates the headless speculative-create bulk. Fail loudly rather
         # than silently ignore it.
         raise click.UsageError("--create cannot be combined with --review")
-    resolver = Resolver[Entity].make_default()
-    resolver.begin()
+    session = make_session()
+    resolver = Resolver[Entity](session, create=True)
+    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     algorithm_type = get_algorithm(algorithm)
     if algorithm_type is None:
         raise click.Abort(f"Unknown algorithm: {algorithm}")
     dataset = Dataset.make({"name": "wikidata", "title": "Wikidata"})
-    session = make_session()
     cache = Cache(session, dataset, create=True)
     client = WikidataClient(cache)
     try:
@@ -199,9 +198,8 @@ def wikidata_reconcile(
                 source_url=source_url,
             )
     finally:
-        # Persist cached API responses even if the run is cancelled or errors.
+        # Persist cached API responses and judgements even if cancelled or errored.
         session.commit()
-    resolver.commit()
     # One QS batch sits next to the input file: entities.ijson.qs. Each create is
     # a contiguous CREATE…LAST unit, so it coexists with enrich statements (which
     # target existing QIDs) in a single batch the operator runs in the QS UI.
@@ -219,10 +217,10 @@ def _write_qs(path: Path, commands: list[QSCommand]) -> None:
 
 @cli.command("prune", help="Remove dedupe candidates")
 def xref_prune() -> None:
-    resolver = Resolver[Entity].make_default()
-    resolver.begin()
-    resolver.prune()
-    resolver.commit()
+    with make_session() as session:
+        resolver = Resolver[Entity](session, create=True)
+        resolver.load_into_memory()
+        resolver.prune()
 
 
 @cli.command("apply", help="Apply resolver to an entity stream")
@@ -257,16 +255,17 @@ def make_sortable(path: Path, outpath: Path) -> None:
 @click.option("-x", "--xref", is_flag=True, default=False)
 @click.option("-p", "--data-path", type=Path, default=None)
 def dedupe(path: Path, xref: bool = False, data_path: Optional[Path] = None) -> None:
-    resolver = Resolver[Entity].make_default()
-    resolver.begin()
-    data_path = _get_data_path(data_path)
-    store = load_entity_file_store(path, resolver=resolver)
-    if xref:
-        index_dir = data_path / INDEX_SEGMENT
-        run_xref(resolver, store, index_dir)
-    resolver.commit()
+    with make_session() as session:
+        resolver = Resolver[Entity](session, create=True)
+        resolver.load_into_memory()
+        data_path = _get_data_path(data_path)
+        store = load_entity_file_store(path, resolver=resolver)
+        if xref:
+            index_dir = data_path / INDEX_SEGMENT
+            run_xref(resolver, session, store, index_dir)
+        session.checkpoint()
 
-    dedupe_ui(resolver, store)
+        dedupe_ui(resolver, session, store)
 
 
 @cli.command("train-v1-matcher", help="Train a matching model from judgement pairs")
@@ -290,16 +289,15 @@ def match_command(
     entities: Path,
     outpath: Path,
 ) -> None:
-    resolver = Resolver[Entity].make_default()
     with make_session() as session:
+        resolver = Resolver[Entity](session, create=True)
+        resolver.load_into_memory()
         _, enricher = _load_enricher(session, config)
         try:
-            resolver.begin()
             with path_writer(outpath) as fh:
                 stream = path_entities(entities, Entity)
                 for proxy in match(enricher, resolver, stream):
                     write_entity(fh, proxy)
-            resolver.commit()
         finally:
             enricher.close()
 
@@ -313,16 +311,15 @@ def enrich_command(
     entities: Path,
     outpath: Path,
 ) -> None:
-    resolver = Resolver[Entity].make_default()
     with make_session() as session:
+        resolver = Resolver[Entity](session, create=True)
+        resolver.load_into_memory()
         _, enricher = _load_enricher(session, config)
         try:
-            resolver.begin()
             with path_writer(outpath) as fh:
                 stream = path_entities(entities, Entity)
                 for proxy in enrich(enricher, resolver, stream):
                     write_entity(fh, proxy)
-            resolver.commit()
         finally:
             enricher.close()
 
@@ -345,19 +342,17 @@ def statements_apply(infile: Path, outpath: Path, format: str) -> None:
 @cli.command("load-resolver", help="Load resolver edges from file into database")
 @click.argument("source", type=InPath)
 def load_resolver(source: Path) -> None:
-    resolver = Resolver[Entity].make_default()
-    resolver.begin()
-    resolver.load(source)
-    resolver.commit()
+    with make_session() as session:
+        resolver = Resolver[Entity](session, create=True)
+        resolver.load(source)
 
 
 @cli.command("dump-resolver", help="Dump resolver decisions from database to file")
 @click.argument("target", type=OutPath)
 def dump_resolver(target: Path) -> None:
-    resolver = Resolver[Entity].make_default()
-    resolver.begin()
-    resolver.dump(target)
-    resolver.rollback()
+    with make_session() as session:
+        resolver = Resolver[Entity](session, create=True)
+        resolver.dump(target)
 
 
 @cli.command("bench", help="Benchmark a matching algorithm")

--- a/nomenklatura/cli.py
+++ b/nomenklatura/cli.py
@@ -12,6 +12,7 @@ from followthemoney.cli.util import path_entities, write_entity
 from followthemoney.cli.aggregate import sorted_aggregate
 
 from nomenklatura.cache import Cache
+from nomenklatura.db import make_session, Session
 from nomenklatura.matching import train_v1_matcher, train_erun_matcher
 from nomenklatura.store import load_entity_file_store
 from nomenklatura.resolver import Resolver, Linker
@@ -31,11 +32,13 @@ log = logging.getLogger(__name__)
 ResPath = click.Path(dir_okay=False, writable=True, path_type=Path)
 
 
-def _load_enricher(path: Path) -> Tuple[Dataset, Enricher[Dataset]]:
+def _load_enricher(
+    session: Session, path: Path
+) -> Tuple[Dataset, Enricher[Dataset]]:
     with open(path, "r") as fh:
         data = yaml.safe_load(fh)
         dataset = Dataset.make(data)
-        cache = Cache.make_default(dataset)
+        cache = Cache(session, dataset, create=True)
         enricher = make_enricher(dataset, cache, data)
         if enricher is None:
             raise TypeError("Could not load enricher")
@@ -165,12 +168,14 @@ def wikidata_reconcile(
     if algorithm_type is None:
         raise click.Abort(f"Unknown algorithm: {algorithm}")
     dataset = Dataset.make({"name": "wikidata", "title": "Wikidata"})
-    cache = Cache.make_default(dataset)
+    session = make_session()
+    cache = Cache(session, dataset, create=True)
     client = WikidataClient(cache)
     try:
         if review:
             commands = reconcile_ui(
                 resolver,
+                session,
                 store,
                 client,
                 dataset,
@@ -182,6 +187,7 @@ def wikidata_reconcile(
         else:
             commands = run_reconcile(
                 resolver,
+                session,
                 store,
                 client,
                 dataset,
@@ -194,7 +200,7 @@ def wikidata_reconcile(
             )
     finally:
         # Persist cached API responses even if the run is cancelled or errors.
-        cache.close()
+        session.commit()
     resolver.commit()
     # One QS batch sits next to the input file: entities.ijson.qs. Each create is
     # a contiguous CREATE…LAST unit, so it coexists with enrich statements (which
@@ -285,17 +291,17 @@ def match_command(
     outpath: Path,
 ) -> None:
     resolver = Resolver[Entity].make_default()
-    _, enricher = _load_enricher(config)
-
-    try:
-        resolver.begin()
-        with path_writer(outpath) as fh:
-            stream = path_entities(entities, Entity)
-            for proxy in match(enricher, resolver, stream):
-                write_entity(fh, proxy)
-        resolver.commit()
-    finally:
-        enricher.close()
+    with make_session() as session:
+        _, enricher = _load_enricher(session, config)
+        try:
+            resolver.begin()
+            with path_writer(outpath) as fh:
+                stream = path_entities(entities, Entity)
+                for proxy in match(enricher, resolver, stream):
+                    write_entity(fh, proxy)
+            resolver.commit()
+        finally:
+            enricher.close()
 
 
 @cli.command("enrich", help="Fetch extra info from an enrichment source")
@@ -308,16 +314,17 @@ def enrich_command(
     outpath: Path,
 ) -> None:
     resolver = Resolver[Entity].make_default()
-    _, enricher = _load_enricher(config)
-    try:
-        resolver.begin()
-        with path_writer(outpath) as fh:
-            stream = path_entities(entities, Entity)
-            for proxy in enrich(enricher, resolver, stream):
-                write_entity(fh, proxy)
-        resolver.commit()
-    finally:
-        enricher.close()
+    with make_session() as session:
+        _, enricher = _load_enricher(session, config)
+        try:
+            resolver.begin()
+            with path_writer(outpath) as fh:
+                stream = path_entities(entities, Entity)
+                for proxy in enrich(enricher, resolver, stream):
+                    write_entity(fh, proxy)
+            resolver.commit()
+        finally:
+            enricher.close()
 
 
 @cli.command("apply-statements", help="Apply a resolver file to a set of statements")

--- a/nomenklatura/cli.py
+++ b/nomenklatura/cli.py
@@ -161,16 +161,16 @@ def wikidata_reconcile(
         # than silently ignore it.
         raise click.UsageError("--create cannot be combined with --review")
     session = make_session()
-    resolver = Resolver[Entity](session, create=True)
-    resolver.load_into_memory()
-    store = load_entity_file_store(path, resolver=resolver)
-    algorithm_type = get_algorithm(algorithm)
-    if algorithm_type is None:
-        raise click.Abort(f"Unknown algorithm: {algorithm}")
-    dataset = Dataset.make({"name": "wikidata", "title": "Wikidata"})
-    cache = Cache(session, dataset, create=True)
-    client = WikidataClient(cache)
     try:
+        resolver = Resolver[Entity](session, create=True)
+        resolver.load_into_memory()
+        store = load_entity_file_store(path, resolver=resolver)
+        algorithm_type = get_algorithm(algorithm)
+        if algorithm_type is None:
+            raise click.Abort(f"Unknown algorithm: {algorithm}")
+        dataset = Dataset.make({"name": "wikidata", "title": "Wikidata"})
+        cache = Cache(session, dataset, create=True)
+        client = WikidataClient(cache)
         if review:
             commands = reconcile_ui(
                 resolver,

--- a/nomenklatura/cli.py
+++ b/nomenklatura/cli.py
@@ -156,9 +156,7 @@ def wikidata_reconcile(
     create: bool = False,
 ) -> None:
     if review and create:
-        # In review mode creates come from a keypress, so --create is meaningless;
-        # it only gates the headless speculative-create bulk. Fail loudly rather
-        # than silently ignore it.
+        # Review mode creates items interactively.
         raise click.UsageError("--create cannot be combined with --review")
     session = make_session()
     try:
@@ -198,11 +196,8 @@ def wikidata_reconcile(
                 source_url=source_url,
             )
     finally:
-        # Persist cached API responses and judgements even if cancelled or errored.
+        # Keep completed requests and judgements after an interrupted run.
         session.commit()
-    # One QS batch sits next to the input file: entities.ijson.qs. Each create is
-    # a contiguous CREATE…LAST unit, so it coexists with enrich statements (which
-    # target existing QIDs) in a single batch the operator runs in the QS UI.
     _write_qs(path.with_name(path.name + ".qs"), commands)
     log.info("Reconcile complete in: %r", resolver)
 

--- a/nomenklatura/db.py
+++ b/nomenklatura/db.py
@@ -15,7 +15,8 @@ from sqlalchemy import (
     create_engine,
     delete,
 )
-from sqlalchemy.engine import Connection, Dialect, Engine
+from sqlalchemy.engine import Connection, CursorResult, Dialect, Engine
+from sqlalchemy.sql.expression import Executable
 from sqlalchemy.dialects.postgresql import insert as psql_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
@@ -70,6 +71,112 @@ def close_db(url: Optional[str] = None) -> None:
 @cache
 def get_metadata() -> MetaData:
     return MetaData()
+
+
+class Session:
+    """A single unit of work over one database connection.
+
+    Hand one to the data-access objects that should share a transaction (Cache,
+    Resolver, the stateful zavod tables) so the *owner* of the work — a zavod
+    Context, a CLI command — controls one commit boundary, instead of each
+    object conjuring and holding its own connection. Runs in SQLAlchemy
+    "commit-as-you-go" mode: the first ``execute`` opens a transaction and
+    ``checkpoint`` ends it while keeping the connection ready for the next, so a
+    long run commits on a frequent cadence and never pins Postgres ``xmin`` for
+    hours (the cause of the cache/resolver table bloat in production).
+
+    The session is deliberately domain-blind: it owns connection lifetime and
+    dialect, and nothing else. It holds no ``MetaData`` — table definitions are
+    a consumer/module concern (a ``Table`` runs on any connection regardless of
+    which registry it belongs to). Flushing a consumer's buffers or reloading an
+    in-memory graph around a checkpoint is the owner's job, not the session's.
+    """
+
+    def __init__(self, engine: Engine) -> None:
+        self.engine = engine
+        self._conn: Optional[Connection] = None
+
+    @property
+    def connection(self) -> Connection:
+        """The live connection, checked out from the pool on first use."""
+        if self._conn is None:
+            self._conn = self.engine.connect()
+        return self._conn
+
+    @property
+    def dialect(self) -> Dialect:
+        return self.engine.dialect
+
+    def execute(self, statement: Executable) -> CursorResult[Any]:
+        return self.connection.execute(statement)
+
+    def create(self, *tables: Table) -> None:
+        """Issue ``CREATE TABLE ... IF NOT EXISTS`` for the given tables.
+
+        Creates whatever ``Table`` objects you hand it on this session's
+        connection — independent of which ``MetaData`` they belong to — so the
+        DDL rides on the same connection as the rest of the unit of work.
+        Assumes the tables have no inter-table foreign keys (true across the
+        stack); if that changes, group by metadata and use ``create_all``.
+        """
+        for table in tables:
+            table.create(bind=self.connection, checkfirst=True)
+
+    def checkpoint(self) -> None:
+        """Commit the current transaction and keep going on the same connection.
+
+        The cadence primitive: call this periodically through a long run (e.g.
+        every N entities) so committed rows become vacuumable and no single
+        transaction stays open for the whole run. The next ``execute`` begins a
+        fresh transaction automatically; the connection is *not* released.
+        """
+        if self._conn is not None:
+            self._conn.commit()
+
+    def commit(self) -> None:
+        """Commit and dispose the connection — the terminal end of the work.
+
+        Use ``checkpoint`` mid-run; use ``commit`` once, when the unit of work
+        is finished and the connection should go back to the pool.
+        """
+        if self._conn is not None:
+            self._conn.commit()
+            self._conn.close()
+            self._conn = None
+
+    def rollback(self) -> None:
+        """Roll back the current transaction, leaving the connection open for retry."""
+        if self._conn is not None:
+            self._conn.rollback()
+
+    def close(self) -> None:
+        """Dispose the connection, rolling back any transaction still open."""
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    def __enter__(self) -> "Session":
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        if exc_type is None:
+            self.commit()
+        else:
+            self.rollback()
+            self.close()
+
+    def __repr__(self) -> str:
+        return f"<Session({self.engine.url!r})>"
+
+
+def make_session(url: Optional[str] = None) -> Session:
+    """Build a unit-of-work session, the single entry point for a db handle.
+
+    Reuses the process-wide connection pool (one engine per URL) but hands back
+    a fresh session with its own connection, so transaction lifetime is
+    explicitly owned by the caller rather than floating in module-level caches.
+    """
+    return Session(get_engine(url))
 
 
 @contextmanager

--- a/nomenklatura/db.py
+++ b/nomenklatura/db.py
@@ -17,7 +17,9 @@ from sqlalchemy import (
 )
 from sqlalchemy.engine import Connection, CursorResult, Dialect, Engine
 from sqlalchemy.sql.expression import Executable
+from sqlalchemy.dialects.postgresql import Insert as PostgreSQLInsert
 from sqlalchemy.dialects.postgresql import insert as psql_insert
+from sqlalchemy.dialects.sqlite import Insert as SQLiteInsert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
 from nomenklatura import settings
@@ -114,6 +116,16 @@ class Session:
 
     def execute(self, statement: Executable) -> CursorResult[Any]:
         return self.connection.execute(statement)
+
+    def insert(self, table: Table) -> PostgreSQLInsert | SQLiteInsert:
+        """Build an insert that supports the active database's upsert API."""
+        if self.is_sqlite:
+            return sqlite_insert(table)
+        if self.is_postgres:
+            return psql_insert(table)
+        raise NotImplementedError(
+            f"Upsert not implemented for dialect {self.dialect.name}"
+        )
 
     def create(self, *tables: Table) -> None:
         """Create the given tables on this session's connection."""

--- a/nomenklatura/db.py
+++ b/nomenklatura/db.py
@@ -74,39 +74,19 @@ def get_metadata() -> MetaData:
 
 
 def is_postgres(dialect: Dialect) -> bool:
-    """Whether the given dialect is PostgreSQL.
-
-    The single source of truth for the dialect predicate that gates upserts,
-    partial indexes, and other backend-specific SQL across the stack. Use it
-    instead of comparing ``dialect.name`` inline — SQLAlchemy reports Postgres
-    as ``"postgresql"`` (never ``"postgres"``), and scattered checks had drifted
-    into three different spellings of this one question.
-    """
+    """Return whether the dialect is PostgreSQL."""
     return dialect.name == "postgresql"
 
 
 def is_sqlite(dialect: Dialect) -> bool:
-    """Whether the given dialect is SQLite. See :func:`is_postgres`."""
+    """Return whether the dialect is SQLite."""
     return dialect.name == "sqlite"
 
 
 class Session:
-    """A single unit of work over one database connection.
+    """Own a single database connection for one unit of work.
 
-    Hand one to the data-access objects that should share a transaction (Cache,
-    Resolver, the stateful zavod tables) so the *owner* of the work — a zavod
-    Context, a CLI command — controls one commit boundary, instead of each
-    object conjuring and holding its own connection. Runs in SQLAlchemy
-    "commit-as-you-go" mode: the first ``execute`` opens a transaction and
-    ``checkpoint`` ends it while keeping the connection ready for the next, so a
-    long run commits on a frequent cadence and never pins Postgres ``xmin`` for
-    hours (the cause of the cache/resolver table bloat in production).
-
-    The session is deliberately domain-blind: it owns connection lifetime and
-    dialect, and nothing else. It holds no ``MetaData`` — table definitions are
-    a consumer/module concern (a ``Table`` runs on any connection regardless of
-    which registry it belongs to). Flushing a consumer's buffers or reloading an
-    in-memory graph around a checkpoint is the owner's job, not the session's.
+    Use this to give several data-access objects the same commit boundary.
     """
 
     def __init__(self, engine: Engine) -> None:
@@ -115,7 +95,7 @@ class Session:
 
     @property
     def connection(self) -> Connection:
-        """The live connection, checked out from the pool on first use."""
+        """Get the connection, checking it out on first use."""
         if self._conn is None:
             self._conn = self.engine.connect()
         return self._conn
@@ -136,34 +116,17 @@ class Session:
         return self.connection.execute(statement)
 
     def create(self, *tables: Table) -> None:
-        """Issue ``CREATE TABLE ... IF NOT EXISTS`` for the given tables.
-
-        Creates whatever ``Table`` objects you hand it on this session's
-        connection — independent of which ``MetaData`` they belong to — so the
-        DDL rides on the same connection as the rest of the unit of work.
-        Assumes the tables have no inter-table foreign keys (true across the
-        stack); if that changes, group by metadata and use ``create_all``.
-        """
+        """Create the given tables on this session's connection."""
         for table in tables:
             table.create(bind=self.connection, checkfirst=True)
 
     def checkpoint(self) -> None:
-        """Commit the current transaction and keep going on the same connection.
-
-        The cadence primitive: call this periodically through a long run (e.g.
-        every N entities) so committed rows become vacuumable and no single
-        transaction stays open for the whole run. The next ``execute`` begins a
-        fresh transaction automatically; the connection is *not* released.
-        """
+        """Commit the current transaction without releasing the connection."""
         if self._conn is not None:
             self._conn.commit()
 
     def commit(self) -> None:
-        """Commit and dispose the connection — the terminal end of the work.
-
-        Use ``checkpoint`` mid-run; use ``commit`` once, when the unit of work
-        is finished and the connection should go back to the pool.
-        """
+        """Commit and return the connection to the pool."""
         if self._conn is not None:
             self._conn.commit()
             self._conn.close()
@@ -195,12 +158,7 @@ class Session:
 
 
 def make_session(url: Optional[str] = None) -> Session:
-    """Build a unit-of-work session, the single entry point for a db handle.
-
-    Reuses the process-wide connection pool (one engine per URL) but hands back
-    a fresh session with its own connection, so transaction lifetime is
-    explicitly owned by the caller rather than floating in module-level caches.
-    """
+    """Build a unit-of-work session from the shared engine pool."""
     return Session(get_engine(url))
 
 

--- a/nomenklatura/db.py
+++ b/nomenklatura/db.py
@@ -73,6 +73,23 @@ def get_metadata() -> MetaData:
     return MetaData()
 
 
+def is_postgres(dialect: Dialect) -> bool:
+    """Whether the given dialect is PostgreSQL.
+
+    The single source of truth for the dialect predicate that gates upserts,
+    partial indexes, and other backend-specific SQL across the stack. Use it
+    instead of comparing ``dialect.name`` inline — SQLAlchemy reports Postgres
+    as ``"postgresql"`` (never ``"postgres"``), and scattered checks had drifted
+    into three different spellings of this one question.
+    """
+    return dialect.name == "postgresql"
+
+
+def is_sqlite(dialect: Dialect) -> bool:
+    """Whether the given dialect is SQLite. See :func:`is_postgres`."""
+    return dialect.name == "sqlite"
+
+
 class Session:
     """A single unit of work over one database connection.
 
@@ -106,6 +123,14 @@ class Session:
     @property
     def dialect(self) -> Dialect:
         return self.engine.dialect
+
+    @property
+    def is_postgres(self) -> bool:
+        return is_postgres(self.dialect)
+
+    @property
+    def is_sqlite(self) -> bool:
+        return is_sqlite(self.dialect)
 
     def execute(self, statement: Executable) -> CursorResult[Any]:
         return self.connection.execute(statement)
@@ -217,11 +242,11 @@ def _upsert_statement_batch(
     dialect: Dialect, conn: Connection, table: Table, batch: List[Mapping[str, Any]]
 ) -> None:
     """Create an upsert statement for the given table and engine."""
-    if dialect.name == "sqlite":
+    if is_sqlite(dialect):
         lstmt = sqlite_insert(table).values(batch)
         lstmt = lstmt.on_conflict_do_nothing(index_elements=["id"])
         conn.execute(lstmt)
-    elif dialect.name in ("postgresql", "postgres"):
+    elif is_postgres(dialect):
         pstmt = psql_insert(table).values(batch)
         pstmt = pstmt.on_conflict_do_nothing(index_elements=["id"])
         conn.execute(pstmt)
@@ -237,7 +262,7 @@ def insert_statements(
     batch_size: int = settings.STATEMENT_BATCH,
 ) -> None:
     dataset_count: int = 0
-    is_postgresql = "postgres" in engine.dialect.name
+    is_postgresql = is_postgres(engine.dialect)
     if not is_postgresql:
         sqlite_max_batch = SQLITE_MAX_VARS // len(table.columns)
         batch_size = min(batch_size, sqlite_max_batch)

--- a/nomenklatura/enrich/common.py
+++ b/nomenklatura/enrich/common.py
@@ -227,6 +227,5 @@ class Enricher(BaseEnricher[DS], ABC):
         raise NotImplementedError()
 
     def close(self) -> None:
-        self.cache.close()
         if self._session is not None:
             self._session.close()

--- a/nomenklatura/resolver/linker.py
+++ b/nomenklatura/resolver/linker.py
@@ -17,6 +17,27 @@ class Linker(Generic[SE]):
     def __init__(self, mapping: Dict[str, Tuple[str, ...]]) -> None:
         self._mapping: Dict[str, Tuple[str, ...]] = mapping
 
+    def add(self, left: str, right: str) -> str:
+        """Fold a positive judgement into the cluster map, returning the canonical.
+
+        The single union primitive: merge the clusters of two IDs and re-point
+        every member at the merged tuple, canonical first. Idempotent — re-adding
+        an edge already inside a cluster rewrites the same tuple — which is what
+        lets the resolver replay a delta without tracking what it already saw.
+        This is the only mutation the map needs: incremental splits never happen,
+        a removed merge is handled by rebuilding the map from scratch.
+        """
+        idents = {left, right}
+        for node in (left, right):
+            cluster = self._mapping.get(node)
+            if cluster is not None:
+                idents.update(cluster)
+        # Sort via Identifier ordering (weight, id) so the canonical lands first.
+        members = tuple(i.id for i in sorted(map(Identifier.get, idents), reverse=True))
+        for node in members:
+            self._mapping[node] = members
+        return members[0]
+
     def connected(self, node: Identifier) -> Set[Identifier]:
         """Return all entities connected to the given node. Constructs Identifier
         objects on the fly from the internal string representation."""

--- a/nomenklatura/resolver/linker.py
+++ b/nomenklatura/resolver/linker.py
@@ -23,11 +23,12 @@ class Linker(Generic[SE]):
         Idempotence lets the resolver replay database updates without tracking
         which edges it has already applied.
         """
-        idents = {left, right}
+        idents: Set[str] = set()
         for node in (left, right):
             cluster = self._mapping.get(node)
             if cluster is not None:
                 idents.update(cluster)
+        idents.update((left, right))
         # Sort via Identifier ordering (weight, id) so the canonical lands first.
         members = tuple(i.id for i in sorted(map(Identifier.get, idents), reverse=True))
         for node in members:
@@ -37,10 +38,11 @@ class Linker(Generic[SE]):
     def connected(self, node: Identifier) -> Set[Identifier]:
         """Return all entities connected to the given node. Constructs Identifier
         objects on the fly from the internal string representation."""
-        cluster = self._mapping.get(node.id)
-        if cluster is None:
-            return {node}
-        return {Identifier.get(n) for n in cluster}
+        return {Identifier.get(n) for n in self.connected_ids(node.id)}
+
+    def connected_ids(self, entity_id: str) -> Tuple[str, ...]:
+        """Return the stored identifiers connected to an entity ID."""
+        return self._mapping.get(entity_id, (entity_id,))
 
     def get_canonical(self, entity_id: str) -> str:
         """Return the canonical identifier for the given entity ID."""

--- a/nomenklatura/resolver/linker.py
+++ b/nomenklatura/resolver/linker.py
@@ -18,14 +18,10 @@ class Linker(Generic[SE]):
         self._mapping: Dict[str, Tuple[str, ...]] = mapping
 
     def add(self, left: str, right: str) -> str:
-        """Fold a positive judgement into the cluster map, returning the canonical.
+        """Merge two identifier clusters and return their canonical.
 
-        The single union primitive: merge the clusters of two IDs and re-point
-        every member at the merged tuple, canonical first. Idempotent — re-adding
-        an edge already inside a cluster rewrites the same tuple — which is what
-        lets the resolver replay a delta without tracking what it already saw.
-        This is the only mutation the map needs: incremental splits never happen,
-        a removed merge is handled by rebuilding the map from scratch.
+        Idempotence lets the resolver replay database updates without tracking
+        which edges it has already applied.
         """
         idents = {left, right}
         for node in (left, right):

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -47,8 +47,7 @@ class Resolver(Linker[SE]):
         table_name: str = "resolver",
     ) -> None:
         self._session = session
-        # Start with None to skip deletes on first load.
-        # We don't have to process deletes to represent the state on first load.
+        # The initial load only needs active edges.
         self._max_ts: Optional[str] = None
         self.edges: Dict[Pair, Edge] = {}
         self.nodes: Dict[Identifier, Set[Edge]] = defaultdict(set)
@@ -129,10 +128,8 @@ class Resolver(Linker[SE]):
     def load_into_memory(self) -> None:
         """Populate the in-memory edge graph from the database.
 
-        The hot reads (get_canonical/get_judgement/connected) walk this graph,
-        not the DB, so a consumer loads once and then reads in memory. Call it
-        again to pick up edges written since — the load is incremental on
-        ``_max_ts``.
+        Resolver reads use this graph; call again to pick up database writes
+        made by another session.
         """
         self._update_from_db()
         self._invalidate()

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -68,6 +68,12 @@ class Resolver(Linker[SE]):
             text("target"),
             **unique_kw,
         )
+        # Backs the candidate scan: NO_JUDGEMENT suggestions ordered by score.
+        suggested = Index(
+            f"{table_name}_judgement_score",
+            text("judgement"),
+            text("score"),
+        )
         self._table = Table(
             table_name,
             MetaData(),
@@ -80,6 +86,7 @@ class Resolver(Linker[SE]):
             Column("created_at", Unicode(28)),
             Column("deleted_at", Unicode(28), nullable=True),
             unique_pair,
+            suggested,
         )
         if create:
             session.create(self._table)

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -19,12 +19,11 @@ from sqlalchemy import (
     or_,
     text,
 )
-from sqlalchemy.engine import Connection, Engine, Transaction
 from sqlalchemy.sql.expression import delete, insert, update
 from followthemoney import registry, Statement, SE
 from followthemoney.util import PathLike
 
-from nomenklatura.db import get_engine
+from nomenklatura.db import Session
 from nomenklatura.judgement import Judgement
 from nomenklatura.resolver.edge import Edge
 from nomenklatura.resolver.identifier import Identifier, Pair, StrIdent
@@ -43,24 +42,21 @@ class Resolver(Linker[SE]):
 
     def __init__(
         self,
-        engine: Engine,
-        metadata: MetaData,
+        session: Session,
         create: bool = False,
         table_name: str = "resolver",
     ) -> None:
-        self._engine = engine
-        self._conn: Optional[Connection] = None
-        self._transaction: Optional[Transaction] = None
-        # Start with None to skip deletes on first BEGIN.
+        self._session = session
+        # Start with None to skip deletes on first load.
         # We don't have to process deletes to represent the state on first load.
         self._max_ts: Optional[str] = None
         self.edges: Dict[Pair, Edge] = {}
         self.nodes: Dict[Identifier, Set[Edge]] = defaultdict(set)
 
         unique_kw: Dict[str, Any] = {"unique": True}
-        if engine.dialect.name == "sqlite":
+        if session.dialect.name == "sqlite":
             unique_kw["sqlite_where"] = text("deleted_at IS NULL")
-        if engine.dialect.name in ("postgresql", "postgres"):
+        if session.dialect.name in ("postgresql", "postgres"):
             unique_kw["postgresql_where"] = text("deleted_at IS NULL")
         unique_pair = Index(
             f"{table_name}_source_target_uniq",
@@ -70,7 +66,7 @@ class Resolver(Linker[SE]):
         )
         self._table = Table(
             table_name,
-            metadata,
+            MetaData(),
             Column("id", Integer(), primary_key=True),
             Column("target", Unicode(512), index=True),
             Column("source", Unicode(512), index=True),
@@ -80,10 +76,9 @@ class Resolver(Linker[SE]):
             Column("created_at", Unicode(28)),
             Column("deleted_at", Unicode(28), nullable=True),
             unique_pair,
-            extend_existing=True,
         )
         if create:
-            metadata.create_all(bind=engine, checkfirst=True, tables=[self._table])
+            session.create(self._table)
 
     def _update_from_db(self) -> None:
         """Apply new deletes and unseen edges from the database."""
@@ -99,7 +94,7 @@ class Resolver(Linker[SE]):
             )
         stmt.order_by(self._table.c.deleted_at.asc().nulls_last())
         stmt.order_by(self._table.c.created_at.asc())
-        cursor = self._get_connection().execute(stmt)
+        cursor = self._session.execute(stmt)
         while batch := cursor.fetchmany(10000):
             for row in batch:
                 edge = Edge.from_dict(row._mapping)
@@ -128,75 +123,32 @@ class Resolver(Linker[SE]):
                     if len(self.nodes[node]) == 0:
                         del self.nodes[node]
 
-    @classmethod
-    def make_default(cls, engine: Optional[Engine] = None) -> "Resolver[SE]":
-        if engine is None:
-            engine = get_engine()
-        meta = MetaData()
-        return cls(engine, meta, create=True)
-
     def _invalidate(self) -> None:
         pass
 
-    def begin(self, load_edges: bool = True) -> None:
-        """
-        Start a new transaction in Begin Once style. Callers are responsible for
-        committing or rolling back the transaction.
+    def load_into_memory(self) -> None:
+        """Populate the in-memory edge graph from the database.
 
-        https://docs.sqlalchemy.org/en/20/core/connections.html#begin-once
+        The hot reads (get_canonical/get_judgement/connected) walk this graph,
+        not the DB, so a consumer loads once and then reads in memory. Call it
+        again to pick up edges written since — the load is incremental on
+        ``_max_ts``.
         """
-        if self._conn is None:
-            self._conn = self._engine.connect()
-        if self._transaction is None:
-            self._transaction = self._conn.begin()
-        if load_edges:
-            self._update_from_db()
+        self._update_from_db()
         self._invalidate()
 
-    def commit(self) -> None:
-        if self._transaction is None or self._conn is None:
-            self._transaction = None
-            self._conn = None
-            return
+    def cleanup_dead_edges(self) -> None:
+        """Hard-delete soft-deleted NO_JUDGEMENT edges.
 
-        # Swipe up all NO JUDGEMENT edges that have been deleted:
+        Reach for this from the session owner before a checkpoint to reclaim
+        rows; it used to ride inside the now-removed ``commit()``.
+        """
         clean_stmt = delete(self._table)
         clean_stmt = clean_stmt.where(
             self._table.c.judgement == Judgement.NO_JUDGEMENT.value
         )
         clean_stmt = clean_stmt.where(self._table.c.deleted_at.is_not(None))
-        self._conn.execute(clean_stmt)
-
-        self._transaction.commit()
-        self._transaction = None
-        self._conn.close()
-        self._conn = None
-
-    def rollback(self) -> None:
-        if self._transaction is not None:
-            self._transaction.rollback()
-            self._transaction = None
-        if self._conn is not None:
-            self._conn.close()
-            self._conn = None
-
-    def close(self) -> None:
-        """Close the resolver connection."""
-        if self._transaction is not None:
-            self._transaction.rollback()
-            self._transaction = None
-        if self._conn is not None:
-            self._conn.close()
-            self._conn = None
-        self.edges.clear()
-        self.nodes.clear()
-        self._max_ts = None
-        self._invalidate()
-
-    def _get_connection(self) -> Connection:
-        if self._transaction is None or self._conn is None:
-            raise RuntimeError("No transaction in progress.")
-        return self._conn
+        self._session.execute(clean_stmt)
 
     def get_linker(self) -> Linker[SE]:
         """Return a linker object that can be used to resolve entities.
@@ -207,23 +159,22 @@ class Resolver(Linker[SE]):
         stmt = stmt.where(self._table.c.judgement == Judgement.POSITIVE.value)
         stmt = stmt.where(self._table.c.deleted_at.is_(None))
         stmt.order_by(self._table.c.created_at.asc())
-        with self._engine.connect() as conn:
-            cursor = conn.execute(stmt)
-            while batch := cursor.fetchmany(20000):
-                for row in batch:
-                    source_id: str = row.source
-                    target_id: str = row.target
-                    idents = set([Identifier.get(source_id), Identifier.get(target_id)])
-                    sources = mapping.get(source_id)
-                    if sources is not None:
-                        idents.update(Identifier.get(n) for n in sources)
-                    targets = mapping.get(target_id)
-                    if targets is not None:
-                        idents.update(Identifier.get(n) for n in targets)
-                    cluster = tuple(i.id for i in sorted(idents, reverse=True))
-                    for node in cluster:
-                        mapping[node] = cluster
-            cursor.close()
+        cursor = self._session.execute(stmt)
+        while batch := cursor.fetchmany(20000):
+            for row in batch:
+                source_id: str = row.source
+                target_id: str = row.target
+                idents = set([Identifier.get(source_id), Identifier.get(target_id)])
+                sources = mapping.get(source_id)
+                if sources is not None:
+                    idents.update(Identifier.get(n) for n in sources)
+                targets = mapping.get(target_id)
+                if targets is not None:
+                    idents.update(Identifier.get(n) for n in targets)
+                cluster = tuple(i.id for i in sorted(idents, reverse=True))
+                for node in cluster:
+                    mapping[node] = cluster
+        cursor.close()
         return Linker(mapping)
 
     def get_edge(self, left_id: StrIdent, right_id: StrIdent) -> Optional[Edge]:
@@ -347,7 +298,7 @@ class Resolver(Linker[SE]):
         stmt = stmt.order_by(self._table.c.created_at.desc())
         if limit is not None:
             stmt = stmt.limit(limit)
-        cursor = self._get_connection().execute(stmt)
+        cursor = self._session.execute(stmt)
         while batch := cursor.fetchmany(25):
             for row in batch:
                 yield Edge.from_dict(row._mapping)
@@ -395,7 +346,7 @@ class Resolver(Linker[SE]):
                     self._table.c.judgement == Judgement.NO_JUDGEMENT.value
                 )
                 stmt = stmt.values({"score": score})
-                self._get_connection().execute(stmt)
+                self._session.execute(stmt)
 
                 # local state
                 edge.score = score
@@ -448,10 +399,10 @@ class Resolver(Linker[SE]):
         ustmt = ustmt.where(self._table.c.source == edge.source.id)
         ustmt = ustmt.where(self._table.c.target == edge.target.id)
         ustmt = ustmt.where(self._table.c.deleted_at.is_(None))
-        self._get_connection().execute(ustmt)
+        self._session.execute(ustmt)
 
         stmt = insert(self._table).values(edge.to_dict())
-        self._get_connection().execute(stmt)
+        self._session.execute(stmt)
         self._update_edge(edge)
 
     def _remove_edge(self, edge: Edge) -> None:
@@ -462,7 +413,7 @@ class Resolver(Linker[SE]):
         stmt = stmt.where(self._table.c.target == edge.target.id)
         stmt = stmt.where(self._table.c.source == edge.source.id)
         stmt = stmt.where(self._table.c.deleted_at.is_(None))
-        self._get_connection().execute(stmt)
+        self._session.execute(stmt)
         self._update_edge(edge)
 
     def _remove_node(self, node: Identifier) -> None:
@@ -476,7 +427,7 @@ class Resolver(Linker[SE]):
         )
         stmt = stmt.where(cond)
         stmt = stmt.where(self._table.c.deleted_at.is_(None))
-        self._get_connection().execute(stmt)
+        self._session.execute(stmt)
 
         edges = self.nodes.get(node)
         if edges is None:
@@ -515,7 +466,7 @@ class Resolver(Linker[SE]):
         stmt = stmt.where(self._table.c.judgement == Judgement.NO_JUDGEMENT.value)
         if user is not None:
             stmt = stmt.where(self._table.c.user == user)
-        self._get_connection().execute(stmt)
+        self._session.execute(stmt)
 
         # local state
         now = timestamp()
@@ -619,7 +570,7 @@ class Resolver(Linker[SE]):
         stmt = stmt.where(self._table.c.judgement != Judgement.NO_JUDGEMENT.value)
         stmt.order_by(self._table.c.created_at.asc())
         with open(path, "w") as fh:
-            cursor = self._get_connection().execute(stmt)
+            cursor = self._session.execute(stmt)
             for row in cursor.yield_per(20000):
                 edge = Edge.from_dict(row._mapping)
                 fh.write(edge.to_line())
@@ -641,6 +592,6 @@ class Resolver(Linker[SE]):
         self._invalidate()
 
     def __repr__(self) -> str:
-        parts = self._engine.url
+        parts = self._session.engine.url
         url = f"{parts.drivername}://{parts.host or ''}/{parts.database}/{self._table.name}"
         return f"<Resolver({url})>"

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -54,9 +54,9 @@ class Resolver(Linker[SE]):
         self.nodes: Dict[Identifier, Set[Edge]] = defaultdict(set)
 
         unique_kw: Dict[str, Any] = {"unique": True}
-        if session.dialect.name == "sqlite":
+        if session.is_sqlite:
             unique_kw["sqlite_where"] = text("deleted_at IS NULL")
-        if session.dialect.name in ("postgresql", "postgres"):
+        if session.is_postgres:
             unique_kw["postgresql_where"] = text("deleted_at IS NULL")
         unique_pair = Index(
             f"{table_name}_source_target_uniq",

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -51,6 +51,15 @@ class Resolver(Linker[SE]):
         self._max_ts: Optional[str] = None
         self.edges: Dict[Pair, Edge] = {}
         self.nodes: Dict[Identifier, Set[Edge]] = defaultdict(set)
+        # Derived positive-cluster index for the hot reads. Maintained
+        # incrementally on positive adds; rebuilt wholesale after a positive
+        # edge is removed (rare), since the flat map cannot un-merge in place.
+        self._linker: Linker[SE] = Linker({})
+        self._linker_dirty = False
+        # Blocking judgements (negative/unsure) keyed by raw id pair. Raw keys
+        # never drift on merges, so this is maintained fully incrementally — a
+        # removed blocker is just a pop, no rebuild.
+        self._blockers: Dict[Pair, Judgement] = {}
 
         unique_kw: Dict[str, Any] = {"unique": True}
         if session.is_sqlite:
@@ -114,13 +123,35 @@ class Resolver(Linker[SE]):
             self.edges[edge.key] = edge
             self.nodes[edge.source].add(edge)
             self.nodes[edge.target].add(edge)
+            if edge.judgement == Judgement.POSITIVE:
+                self._linker.add(edge.source.id, edge.target.id)
+            elif edge.judgement in (Judgement.NEGATIVE, Judgement.UNSURE):
+                self._blockers[edge.key] = edge.judgement
         else:
-            self.edges.pop(edge.key, None)
+            existed = self.edges.pop(edge.key, None)
+            self._blockers.pop(edge.key, None)
             for node in (edge.source, edge.target):
                 if node in self.nodes:
                     self.nodes[node].discard(edge)
                     if len(self.nodes[node]) == 0:
                         del self.nodes[node]
+            # A removed positive edge may split a cluster; the flat map can't
+            # do that incrementally, so flag a rebuild on next read.
+            if existed is not None and existed.judgement == Judgement.POSITIVE:
+                self._linker_dirty = True
+
+    def _rebuild_linker(self) -> None:
+        linker: Linker[SE] = Linker({})
+        for edge in self.edges.values():
+            if edge.judgement == Judgement.POSITIVE:
+                linker.add(edge.source.id, edge.target.id)
+        self._linker = linker
+        self._linker_dirty = False
+
+    def _linker_view(self) -> Linker[SE]:
+        if self._linker_dirty:
+            self._rebuild_linker()
+        return self._linker
 
     def _invalidate(self) -> None:
         pass
@@ -138,7 +169,7 @@ class Resolver(Linker[SE]):
         """Return a linker object that can be used to resolve entities.
         This is less memory-consuming than the full resolver object.
         """
-        mapping: Dict[str, Tuple[str, ...]] = {}
+        linker: Linker[SE] = Linker({})
         stmt = self._table.select()
         stmt = stmt.where(self._table.c.judgement == Judgement.POSITIVE.value)
         stmt = stmt.where(self._table.c.deleted_at.is_(None))
@@ -146,41 +177,16 @@ class Resolver(Linker[SE]):
         cursor = self._session.execute(stmt)
         while batch := cursor.fetchmany(20000):
             for row in batch:
-                source_id: str = row.source
-                target_id: str = row.target
-                idents = set([Identifier.get(source_id), Identifier.get(target_id)])
-                sources = mapping.get(source_id)
-                if sources is not None:
-                    idents.update(Identifier.get(n) for n in sources)
-                targets = mapping.get(target_id)
-                if targets is not None:
-                    idents.update(Identifier.get(n) for n in targets)
-                cluster = tuple(i.id for i in sorted(idents, reverse=True))
-                for node in cluster:
-                    mapping[node] = cluster
+                linker.add(row.source, row.target)
         cursor.close()
-        return Linker(mapping)
+        return linker
 
     def get_edge(self, left_id: StrIdent, right_id: StrIdent) -> Optional[Edge]:
         key = Identifier.pair(left_id, right_id)
         return self.edges.get(key)
 
-    def _traverse(self, node: Identifier, seen: Set[Identifier]) -> Set[Identifier]:
-        """Returns the set of nodes connected to the given node via positive judgement."""
-        connected = set([node])
-        if node in seen:
-            return connected
-        seen.add(node)
-        for edge in self.nodes.get(node, []):
-            if edge.judgement == Judgement.POSITIVE:
-                other = edge.other(node)
-                rec = self._traverse(other, seen)
-                connected.update(rec)
-        return connected
-
-    # @lru_cache(maxsize=200000)
     def connected(self, node: Identifier) -> Set[Identifier]:
-        return self._traverse(node, set())
+        return self._linker_view().connected(node)
 
     def get_canonical(self, entity_id: str) -> str:
         """Return the canonical identifier for the given entity ID."""
@@ -231,12 +237,6 @@ class Resolver(Linker[SE]):
                 return edge
         return None
 
-    def _pair_judgement(self, left: Identifier, right: Identifier) -> Judgement:
-        edge = self.get_edge(left, right)
-        if edge is not None:
-            return edge.judgement
-        return Judgement.NO_JUDGEMENT
-
     def get_judgement(self, entity_id: StrIdent, other_id: StrIdent) -> Judgement:
         """Get the existing decision between two entities with dedupe factored in."""
         entity = Identifier.get(entity_id)
@@ -251,17 +251,14 @@ class Resolver(Linker[SE]):
         if is_qid(entity.id) and is_qid(other.id):
             return Judgement.NEGATIVE
 
-        # HACK: this would mark pairs only as unsure if the unsure judgement
-        # had been made on the current canonical combination:
-        # canon_edge = self._pair_judgement(max(entity_connected), max(other_connected))
-        # if canon_edge == Judgement.UNSURE:
-        #     return Judgement.UNSURE
-
+        # Any blocking (negative/unsure) edge spanning the two clusters decides
+        # the pair. A positive edge can't span them — it would have merged the
+        # clusters above — so only blockers remain to check.
         other_connected = self.connected(other)
         for e in entity_connected:
             for o in other_connected:
-                judgement = self._pair_judgement(e, o)
-                if judgement != Judgement.NO_JUDGEMENT:
+                judgement = self._blockers.get(Identifier.pair(e, o))
+                if judgement is not None:
                     return judgement
 
         return Judgement.NO_JUDGEMENT

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -161,10 +161,10 @@ class Resolver(Linker[SE]):
     def load_into_memory(self) -> None:
         """Load the in-memory indexes from the database.
 
-        Resolver reads use these indexes; call again to pick up database writes
-        made by another session.
+        Call this to pick up database writes made by another session. A full
+        rebuild is required because commit order can differ from write order.
         """
-        self._update_from_db()
+        self._load_all()
 
     def get_linker(self) -> Linker[SE]:
         """Return a linker object that can be used to resolve entities.

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -1,10 +1,11 @@
 #
-# Don't forget to call self._invalidate from methods that modify edges.
+# The in-memory state (the cluster linker and the blocker cache) is a pure
+# function of the table: write methods only touch the DB, then call
+# _update_from_db to refresh. Don't mutate the indexes directly.
 #
 from datetime import timedelta
 import getpass
 import logging
-from collections import defaultdict
 from typing import Any, Dict, Generator, List, Optional, Set, Tuple
 from rigour.ids.wikidata import is_qid
 from rigour.time import utc_now
@@ -49,16 +50,11 @@ class Resolver(Linker[SE]):
         self._session = session
         # The initial load only needs active edges.
         self._max_ts: Optional[str] = None
-        self.edges: Dict[Pair, Edge] = {}
-        self.nodes: Dict[Identifier, Set[Edge]] = defaultdict(set)
-        # Derived positive-cluster index for the hot reads. Maintained
-        # incrementally on positive adds; rebuilt wholesale after a positive
-        # edge is removed (rare), since the flat map cannot un-merge in place.
+        # In-memory indexes, both pure functions of the table refreshed by
+        # _update_from_db: the positive-merge cluster map that answers the hot
+        # reads, and a raw-keyed cache of blocking (negative/unsure) judgements.
+        # No full edge graph is held — suggestions live only in the table.
         self._linker: Linker[SE] = Linker({})
-        self._linker_dirty = False
-        # Blocking judgements (negative/unsure) keyed by raw id pair. Raw keys
-        # never drift on merges, so this is maintained fully incrementally — a
-        # removed blocker is just a pop, no rebuild.
         self._blockers: Dict[Pair, Judgement] = {}
 
         unique_kw: Dict[str, Any] = {"unique": True}
@@ -88,82 +84,80 @@ class Resolver(Linker[SE]):
         if create:
             session.create(self._table)
 
-    def _update_from_db(self) -> None:
-        """Apply new deletes and unseen edges from the database."""
-        stmt = self._table.select()
-        if self._max_ts is None:
-            stmt = stmt.where(self._table.c.deleted_at.is_(None))
-        else:
-            stmt = stmt.where(
-                or_(
-                    self._table.c.deleted_at > self._max_ts,
-                    self._table.c.created_at > self._max_ts,
-                )
-            )
-        stmt.order_by(self._table.c.deleted_at.asc().nulls_last())
-        stmt.order_by(self._table.c.created_at.asc())
+    def _index_edge(self, edge: Edge) -> None:
+        """Fold a single live edge into the in-memory indexes."""
+        if edge.judgement == Judgement.POSITIVE:
+            self._linker.add(edge.source.id, edge.target.id)
+        elif edge.judgement in (Judgement.NEGATIVE, Judgement.UNSURE):
+            self._blockers[edge.key] = edge.judgement
+
+    def _load_all(self) -> None:
+        """Rebuild both indexes from scratch over every live edge."""
+        self._linker = Linker({})
+        self._blockers = {}
+        max_ts: Optional[str] = None
+        stmt = self._table.select().where(self._table.c.deleted_at.is_(None))
         cursor = self._session.execute(stmt)
         while batch := cursor.fetchmany(10000):
             for row in batch:
                 edge = Edge.from_dict(row._mapping)
-                if self._max_ts is None:
-                    self._max_ts = edge.created_at
-                if self._max_ts is not None:
-                    if edge.created_at is not None:
-                        self._max_ts = max(self._max_ts, edge.created_at)
-                    if edge.deleted_at is not None:
-                        self._max_ts = max(self._max_ts, edge.deleted_at)
-                self._update_edge(edge)
+                if edge.created_at is not None:
+                    if max_ts is None or edge.created_at > max_ts:
+                        max_ts = edge.created_at
+                self._index_edge(edge)
         cursor.close()
+        self._max_ts = max_ts
 
-    def _update_edge(self, edge: Edge) -> None:
-        if edge.deleted_at is None:
-            if edge.judgement != Judgement.NO_JUDGEMENT:
-                edge.score = None
-            self.edges[edge.key] = edge
-            self.nodes[edge.source].add(edge)
-            self.nodes[edge.target].add(edge)
-            if edge.judgement == Judgement.POSITIVE:
-                self._linker.add(edge.source.id, edge.target.id)
-            elif edge.judgement in (Judgement.NEGATIVE, Judgement.UNSURE):
-                self._blockers[edge.key] = edge.judgement
+    def _update_from_db(self) -> None:
+        """Refresh the indexes from edges written since the last load.
+
+        Additive deltas (new positive merges, new blockers) fold straight in.
+        A soft-deleted positive edge can split a cluster, which the flat map
+        can't undo in place, so any such removal triggers a full rebuild;
+        deleted blockers are simply dropped. The window is inclusive
+        (``>= _max_ts``) and every apply is idempotent, so an edge written in
+        the same instant as the high-water mark is never missed nor double-
+        counted. Reads its own uncommitted writes via the shared connection.
+        """
+        if self._max_ts is None:
+            self._load_all()
+            return
+        stmt = self._table.select().where(
+            or_(
+                self._table.c.created_at >= self._max_ts,
+                self._table.c.deleted_at >= self._max_ts,
+            )
+        )
+        cursor = self._session.execute(stmt)
+        max_ts = self._max_ts
+        needs_rebuild = False
+        while batch := cursor.fetchmany(10000):
+            for row in batch:
+                edge = Edge.from_dict(row._mapping)
+                if edge.created_at is not None and edge.created_at > max_ts:
+                    max_ts = edge.created_at
+                if edge.deleted_at is not None:
+                    if edge.deleted_at > max_ts:
+                        max_ts = edge.deleted_at
+                    if edge.judgement == Judgement.POSITIVE:
+                        needs_rebuild = True
+                    else:
+                        self._blockers.pop(edge.key, None)
+                else:
+                    self._index_edge(edge)
+        cursor.close()
+        if needs_rebuild:
+            self._load_all()
         else:
-            existed = self.edges.pop(edge.key, None)
-            self._blockers.pop(edge.key, None)
-            for node in (edge.source, edge.target):
-                if node in self.nodes:
-                    self.nodes[node].discard(edge)
-                    if len(self.nodes[node]) == 0:
-                        del self.nodes[node]
-            # A removed positive edge may split a cluster; the flat map can't
-            # do that incrementally, so flag a rebuild on next read.
-            if existed is not None and existed.judgement == Judgement.POSITIVE:
-                self._linker_dirty = True
-
-    def _rebuild_linker(self) -> None:
-        linker: Linker[SE] = Linker({})
-        for edge in self.edges.values():
-            if edge.judgement == Judgement.POSITIVE:
-                linker.add(edge.source.id, edge.target.id)
-        self._linker = linker
-        self._linker_dirty = False
-
-    def _linker_view(self) -> Linker[SE]:
-        if self._linker_dirty:
-            self._rebuild_linker()
-        return self._linker
-
-    def _invalidate(self) -> None:
-        pass
+            self._max_ts = max_ts
 
     def load_into_memory(self) -> None:
-        """Populate the in-memory edge graph from the database.
+        """Load the in-memory indexes from the database.
 
-        Resolver reads use this graph; call again to pick up database writes
+        Resolver reads use these indexes; call again to pick up database writes
         made by another session.
         """
         self._update_from_db()
-        self._invalidate()
 
     def get_linker(self) -> Linker[SE]:
         """Return a linker object that can be used to resolve entities.
@@ -193,7 +187,7 @@ class Resolver(Linker[SE]):
         return Edge.from_dict(row._mapping)
 
     def connected(self, node: Identifier) -> Set[Identifier]:
-        return self._linker_view().connected(node)
+        return self._linker.connected(node)
 
     def get_canonical(self, entity_id: str) -> str:
         """Return the canonical identifier for the given entity ID."""
@@ -205,7 +199,7 @@ class Resolver(Linker[SE]):
 
     def canonicals(self) -> Generator[Identifier, None, None]:
         """Return all the canonical cluster identifiers."""
-        return self._linker_view().canonicals()
+        return self._linker.canonicals()
 
     def get_referents(self, canonical_id: str, canonicals: bool = True) -> Set[str]:
         """Get all the non-canonical entity identifiers which refer to a given
@@ -321,9 +315,7 @@ class Resolver(Linker[SE]):
         edge = self.get_edge(left_id, right_id)
         if edge is not None:
             if edge.judgement == Judgement.NO_JUDGEMENT:
-                # Just update score
-
-                # database
+                # Just update the score; a suggestion touches neither index.
                 stmt = update(self._table)
                 stmt = stmt.where(self._table.c.target == edge.target.id)
                 stmt = stmt.where(self._table.c.source == edge.source.id)
@@ -333,9 +325,6 @@ class Resolver(Linker[SE]):
                 )
                 stmt = stmt.values({"score": score})
                 self._session.execute(stmt)
-
-                # local state
-                edge.score = score
             return edge.target
         return self.decide(
             left_id, right_id, Judgement.NO_JUDGEMENT, score=score, user=user
@@ -349,6 +338,28 @@ class Resolver(Linker[SE]):
         user: Optional[str] = None,
         score: Optional[float] = None,
     ) -> Identifier:
+        result = self._decide(left_id, right_id, judgement, user=user, score=score)
+        # Suggestions don't touch the indexes; everything else does, so refresh
+        # so the caller's next read sees the merge/blocker it just wrote.
+        if judgement != Judgement.NO_JUDGEMENT:
+            self._update_from_db()
+        return result
+
+    def _decide(
+        self,
+        left_id: StrIdent,
+        right_id: StrIdent,
+        judgement: Judgement,
+        user: Optional[str] = None,
+        score: Optional[float] = None,
+    ) -> Identifier:
+        """Write a judgement to the table without refreshing the indexes.
+
+        Recurses to canonicalise positive matches; the public ``decide``
+        refreshes once at the end. The recursion only ever reads the endpoints
+        it is given against a fresh canonical, so the stale-during-recursion
+        index is never consulted for an edge written earlier in the same call.
+        """
         edge = self.get_edge(left_id, right_id)
         if edge is None:
             edge = Edge(left_id, right_id, judgement=judgement)
@@ -362,8 +373,8 @@ class Resolver(Linker[SE]):
             if not target.canonical:
                 canonical = Identifier.make()
                 self._remove_edge(edge)
-                self.decide(edge.source, canonical, judgement=judgement, user=user)
-                self.decide(edge.target, canonical, judgement=judgement, user=user)
+                self._decide(edge.source, canonical, judgement=judgement, user=user)
+                self._decide(edge.target, canonical, judgement=judgement, user=user)
                 return canonical
 
         edge.judgement = judgement
@@ -371,12 +382,10 @@ class Resolver(Linker[SE]):
         edge.user = user or getpass.getuser()
         edge.score = score or edge.score
         self._register(edge)
-        if judgement != Judgement.NO_JUDGEMENT:
-            self._invalidate()
         return edge.target
 
     def _register(self, edge: Edge) -> None:
-        """Ensure the edge exists in the resolver, as provided."""
+        """Write the edge to the table, superseding any live edge for the pair."""
         if edge.judgement != Judgement.NO_JUDGEMENT:
             edge.score = None
 
@@ -389,10 +398,9 @@ class Resolver(Linker[SE]):
 
         stmt = insert(self._table).values(edge.to_dict())
         self._session.execute(stmt)
-        self._update_edge(edge)
 
     def _remove_edge(self, edge: Edge) -> None:
-        """Remove an edge from the graph."""
+        """Soft-delete the live row for the edge's pair, if any."""
         edge.deleted_at = timestamp()
         stmt = update(self._table)
         stmt = stmt.values({"deleted_at": edge.deleted_at})
@@ -400,10 +408,9 @@ class Resolver(Linker[SE]):
         stmt = stmt.where(self._table.c.source == edge.source.id)
         stmt = stmt.where(self._table.c.deleted_at.is_(None))
         self._session.execute(stmt)
-        self._update_edge(edge)
 
     def _remove_node(self, node: Identifier) -> None:
-        """Remove a node from the graph."""
+        """Soft-delete every live edge touching the node."""
         deleted_at = timestamp()
         stmt = update(self._table)
         stmt = stmt.values({"deleted_at": deleted_at})
@@ -415,19 +422,11 @@ class Resolver(Linker[SE]):
         stmt = stmt.where(self._table.c.deleted_at.is_(None))
         self._session.execute(stmt)
 
-        edges = self.nodes.get(node)
-        if edges is None:
-            return
-        for edge in list(edges):
-            edge.deleted_at = deleted_at
-            if edge.judgement != Judgement.NO_JUDGEMENT:
-                self._update_edge(edge)
-
     def remove(self, node_id: StrIdent) -> None:
         """Remove all edges linking to the given node from the graph."""
         node = Identifier.get(node_id)
         self._remove_node(node)
-        self._invalidate()
+        self._update_from_db()
 
     def explode(self, node_id: StrIdent) -> Set[str]:
         """Dissolve all edges linked to the cluster to which the node belongs.
@@ -438,7 +437,7 @@ class Resolver(Linker[SE]):
         for part in self.connected(node):
             affected.add(str(part))
             self._remove_node(part)
-        self._invalidate()
+        self._update_from_db()
         return affected
 
     def prune(
@@ -446,97 +445,122 @@ class Resolver(Linker[SE]):
         cleanup_after: timedelta = timedelta(days=6 * 30),
         user: Optional[str] = None,
     ) -> None:
-        """Remove suggested (i.e. NO_JUDGEMENT) edges."""
-        # database
+        """Drop suggestions and simplify the merge graph, then refresh.
+
+        Three independent passes: discard NO_JUDGEMENT suggestions, redirect
+        positive edges that still point at a raw id onto their canonical, and
+        collapse old canonical-to-canonical intermediate merges. All three are
+        canonical-preserving — no node changes which cluster it resolves to —
+        so ``get_canonical`` stays valid against the pre-prune index throughout,
+        and a single refresh at the end rebuilds the simplified graph.
+        """
+        self._prune_suggestions(user=user)
+        self._prune_noncanonical_targets()
+        cutoff_ts = (utc_now() - cleanup_after).isoformat()[:28]
+        self._prune_intermediate_merges(cutoff_ts)
+        self._update_from_db()
+
+    def _live_edges(self, *conditions: Any) -> List[Edge]:
+        """Materialise the live edges matching the given column conditions."""
+        stmt = self._table.select().where(self._table.c.deleted_at.is_(None))
+        for condition in conditions:
+            stmt = stmt.where(condition)
+        cursor = self._session.execute(stmt)
+        edges = [Edge.from_dict(row._mapping) for row in cursor]
+        cursor.close()
+        return edges
+
+    def _prune_suggestions(self, user: Optional[str] = None) -> None:
+        """Hard-delete NO_JUDGEMENT suggestions (optionally for one user)."""
         stmt = delete(self._table)
         stmt = stmt.where(self._table.c.judgement == Judgement.NO_JUDGEMENT.value)
         if user is not None:
             stmt = stmt.where(self._table.c.user == user)
         self._session.execute(stmt)
 
-        # local state
+    def _prune_noncanonical_targets(self) -> None:
+        """Replace raw positive merge links with edges onto the canonical.
+
+        A positive edge whose target is a raw id bridges two members — e.g. a
+        member-to-member link that merged two existing clusters. Rewriting only
+        one endpoint onto the canonical can drop that bridge and split the
+        cluster when the endpoint already resolves to the winning canonical, so
+        attach *both* endpoints: connectivity is preserved whichever canonical
+        wins, and neither replacement edge has a raw target. The rewrites are
+        canonical-preserving, so ``get_canonical`` stays valid for the rest of
+        the pass against the pre-prune index.
+        """
         now = timestamp()
-        for edge in list(self.edges.values()):
-            if user is not None and edge.user != user:
+        positive = self._table.c.judgement == Judgement.POSITIVE.value
+        for edge in self._live_edges(positive):
+            if edge.target.canonical:
                 continue
-            if edge.judgement == Judgement.NO_JUDGEMENT:
-                edge.deleted_at = now
-                self._update_edge(edge)
-
-        cutoff = utc_now() - cleanup_after
-        cutoff_ts = cutoff.isoformat()[:28]
-
-        for edge in list(self.edges.values()):
-            if edge.deleted_at is not None:
+            canonical = Identifier.get(self.get_canonical(edge.target.id))
+            if not canonical.canonical:
+                log.warning("Invalid target: %s -> %s" % (edge.source, edge.target))
                 continue
+            log.info(
+                "Rewriting edge: %s = %s -> %s" % (edge.target, edge.source, canonical)
+            )
+            self._remove_edge(edge)
+            for member in (edge.source, edge.target):
+                self._register(
+                    Edge(
+                        left_id=member,
+                        right_id=canonical,
+                        judgement=Judgement.POSITIVE,
+                        user=edge.user,
+                        created_at=now,
+                    )
+                )
 
-            # Cleanup job 1: Positive merges where the target is not canonical.
-            if edge.judgement == Judgement.POSITIVE and not edge.target.canonical:
-                nu_target = Identifier.get(self.get_canonical(edge.target.id))
-                if not nu_target.canonical:
-                    log.warning("Invalid target: %s -> %s" % (edge.source, edge.target))
+    def _prune_intermediate_merges(self, cutoff_ts: str) -> None:
+        """Collapse old canonical-to-canonical merges onto the final canonical."""
+        now = timestamp()
+        positive = self._table.c.judgement == Judgement.POSITIVE.value
+        old = self._table.c.created_at < cutoff_ts
+        removed: Set[Pair] = set()
+        for edge in self._live_edges(positive, old):
+            if edge.key in removed:
+                continue
+            if not (edge.source.canonical and edge.target.canonical):
+                continue
+            canonical = Identifier.get(self.get_canonical(edge.source.id))
+            log.info(
+                "Removing intermediate merge: %s -> %s (%s)"
+                % (edge.source, edge.target, canonical)
+            )
+            touching = or_(
+                self._table.c.source == edge.source.id,
+                self._table.c.target == edge.source.id,
+            )
+            for linked_edge in self._live_edges(touching):
+                if linked_edge.key == edge.key or linked_edge.key in removed:
                     continue
-                log.info(
-                    "Rewriting edge: %s = %s -> %s"
-                    % (edge.target, edge.source, nu_target)
-                )
-                nu_edge = Edge(
-                    left_id=edge.source,
-                    right_id=nu_target,
-                    judgement=Judgement.POSITIVE,
-                    user=edge.user,
-                    created_at=now,
-                )
-                self._remove_edge(edge)
-                self._register(nu_edge)
-
-            # Cleanup job 2: Positive merges older than cutoff where both sides
-            # are canonical. These can be simplified and the intermediate canonical IDs
-            # removed.
-            if (
-                edge.source.canonical
-                and edge.target.canonical
-                and edge.judgement == Judgement.POSITIVE
-                and edge.created_at is not None
-                and edge.created_at < cutoff_ts
-            ):
-                canonical = Identifier.get(self.get_canonical(edge.source.id))
-                log.info(
-                    "Removing intermediate merge: %s -> %s (%s)"
-                    % (edge.source, edge.target, canonical)
-                )
-                linked = self.nodes.get(edge.source, set())
-                for linked_edge in list(linked):
-                    if linked_edge == edge:
-                        continue
-                    if linked_edge.deleted_at is not None:
-                        continue
-                    if linked_edge.other(edge.source) == canonical:
-                        log.warning(
-                            " -> Skipping self-referential edge: %s" % linked_edge
+                if linked_edge.other(edge.source) == canonical:
+                    log.warning(" -> Skipping self-referential edge: %s" % linked_edge)
+                else:
+                    log.info(
+                        " -> Rewriting edge: %s <-> %s -> %s (%s)"
+                        % (
+                            edge.source,
+                            linked_edge.other(edge.source),
+                            canonical,
+                            linked_edge.judgement,
                         )
-                    else:
-                        log.info(
-                            " -> Rewriting edge: %s <-> %s -> %s (%s)"
-                            % (
-                                edge.source,
-                                linked_edge.other(edge.source),
-                                canonical,
-                                linked_edge.judgement,
-                            )
-                        )
-                        nu_edge = Edge(
-                            left_id=linked_edge.other(edge.source),
-                            right_id=canonical,
-                            judgement=linked_edge.judgement,
-                            user=linked_edge.user,
-                            created_at=now,
-                        )
-                        self._register(nu_edge)
-                    self._remove_edge(linked_edge)
-                self._remove_edge(edge)
-
-        self._invalidate()
+                    )
+                    nu_edge = Edge(
+                        left_id=linked_edge.other(edge.source),
+                        right_id=canonical,
+                        judgement=linked_edge.judgement,
+                        user=linked_edge.user,
+                        created_at=now,
+                    )
+                    self._register(nu_edge)
+                self._remove_edge(linked_edge)
+                removed.add(linked_edge.key)
+            self._remove_edge(edge)
+            removed.add(edge.key)
 
     def apply_statement(self, stmt: Statement) -> Statement:
         """Canonicalise Statement Entity IDs and ID values"""
@@ -575,7 +599,7 @@ class Resolver(Linker[SE]):
                 if edge_count % 10000 == 0:
                     log.info("Loaded %s edges." % edge_count)
         log.info("Done. Loaded %s edges." % edge_count)
-        self._invalidate()
+        self._update_from_db()
 
     def __repr__(self) -> str:
         parts = self._session.engine.url

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -137,19 +137,6 @@ class Resolver(Linker[SE]):
         self._update_from_db()
         self._invalidate()
 
-    def cleanup_dead_edges(self) -> None:
-        """Hard-delete soft-deleted NO_JUDGEMENT edges.
-
-        Reach for this from the session owner before a checkpoint to reclaim
-        rows; it used to ride inside the now-removed ``commit()``.
-        """
-        clean_stmt = delete(self._table)
-        clean_stmt = clean_stmt.where(
-            self._table.c.judgement == Judgement.NO_JUDGEMENT.value
-        )
-        clean_stmt = clean_stmt.where(self._table.c.deleted_at.is_not(None))
-        self._session.execute(clean_stmt)
-
     def get_linker(self) -> Linker[SE]:
         """Return a linker object that can be used to resolve entities.
         This is less memory-consuming than the full resolver object.

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -435,6 +435,45 @@ class Resolver(Linker[SE]):
         self._remove_node(node)
         self._update_from_db()
 
+    def rename_node(self, old_id: StrIdent, new_id: StrIdent) -> int:
+        """Rewrite every live edge touching an identifier to its replacement.
+
+        Use this when an external identifier has been merged upstream, for
+        example when Wikidata redirects one QID to another and downstream
+        resolver state should pretend the old QID never existed.
+        """
+        old = Identifier.get(old_id)
+        new = Identifier.get(new_id)
+        if old == new:
+            return 0
+
+        now = timestamp()
+        touching = or_(
+            self._table.c.source == old.id,
+            self._table.c.target == old.id,
+        )
+        changed = 0
+        for edge in self._live_edges(touching):
+            left = new if edge.target == old else edge.target
+            right = new if edge.source == old else edge.source
+            self._remove_edge(edge)
+            if left == right:
+                changed += 1
+                continue
+            self._register(
+                Edge(
+                    left_id=left,
+                    right_id=right,
+                    judgement=edge.judgement,
+                    score=edge.score,
+                    user=edge.user,
+                    created_at=now,
+                )
+            )
+            changed += 1
+        self._update_from_db()
+        return changed
+
     def explode(self, node_id: StrIdent) -> Set[str]:
         """Dissolve all edges linked to the cluster to which the node belongs.
         This is the hard way to make sure we re-do context once we realise

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -182,8 +182,15 @@ class Resolver(Linker[SE]):
         return linker
 
     def get_edge(self, left_id: StrIdent, right_id: StrIdent) -> Optional[Edge]:
-        key = Identifier.pair(left_id, right_id)
-        return self.edges.get(key)
+        (target, source) = Identifier.pair(left_id, right_id)
+        stmt = self._table.select()
+        stmt = stmt.where(self._table.c.target == target.id)
+        stmt = stmt.where(self._table.c.source == source.id)
+        stmt = stmt.where(self._table.c.deleted_at.is_(None))
+        row = self._session.execute(stmt).first()
+        if row is None:
+            return None
+        return Edge.from_dict(row._mapping)
 
     def connected(self, node: Identifier) -> Set[Identifier]:
         return self._linker_view().connected(node)
@@ -198,12 +205,7 @@ class Resolver(Linker[SE]):
 
     def canonicals(self) -> Generator[Identifier, None, None]:
         """Return all the canonical cluster identifiers."""
-        for node in self.nodes.keys():
-            if not node.canonical:
-                continue
-            canonical = self.get_canonical(node.id)
-            if canonical == node.id:
-                yield node
+        return self._linker_view().canonicals()
 
     def get_referents(self, canonical_id: str, canonicals: bool = True) -> Set[str]:
         """Get all the non-canonical entity identifiers which refer to a given
@@ -231,10 +233,9 @@ class Resolver(Linker[SE]):
             for o in right_connected:
                 if e == o:
                     continue
-                edge = self.edges.get(Identifier.pair(e, o))
-                if edge is None:
-                    continue
-                return edge
+                edge = self.get_edge(e, o)
+                if edge is not None:
+                    return edge
         return None
 
     def get_judgement(self, entity_id: StrIdent, other_id: StrIdent) -> Judgement:
@@ -287,10 +288,14 @@ class Resolver(Linker[SE]):
 
     def _get_suggested(self) -> List[Edge]:
         """Get all NO_JUDGEMENT edges in descending order of score."""
-        edges_all = self.edges.values()
-        candidates = (e for e in edges_all if e.judgement == Judgement.NO_JUDGEMENT)
-        cmp = lambda x: x.score or -1.0  # noqa
-        return sorted(candidates, key=cmp, reverse=True)
+        stmt = self._table.select()
+        stmt = stmt.where(self._table.c.judgement == Judgement.NO_JUDGEMENT.value)
+        stmt = stmt.where(self._table.c.deleted_at.is_(None))
+        stmt = stmt.order_by(self._table.c.score.desc().nulls_last())
+        cursor = self._session.execute(stmt)
+        edges = [Edge.from_dict(row._mapping) for row in cursor]
+        cursor.close()
+        return edges
 
     def get_candidates(
         self, limit: Optional[int] = None

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -326,23 +326,20 @@ class Resolver(Linker[SE]):
     ) -> Identifier:
         """Make a NO_JUDGEMENT link between two identifiers to suggest that a user
         should make a decision about whether they are the same or not."""
-        edge = self.get_edge(left_id, right_id)
-        if edge is not None:
-            if edge.judgement == Judgement.NO_JUDGEMENT:
-                # Just update the score; a suggestion touches neither index.
-                stmt = update(self._table)
-                stmt = stmt.where(self._table.c.target == edge.target.id)
-                stmt = stmt.where(self._table.c.source == edge.source.id)
-                stmt = stmt.where(self._table.c.deleted_at.is_(None))
-                stmt = stmt.where(
-                    self._table.c.judgement == Judgement.NO_JUDGEMENT.value
-                )
-                stmt = stmt.values({"score": score})
-                self._session.execute(stmt)
-            return edge.target
-        return self.decide(
-            left_id, right_id, Judgement.NO_JUDGEMENT, score=score, user=user
+        edge = Edge(left_id, right_id, judgement=Judgement.NO_JUDGEMENT)
+        edge.created_at = timestamp()
+        edge.user = user or getpass.getuser()
+        edge.score = score
+
+        stmt = self._session.insert(self._table).values(edge.to_dict())
+        stmt = stmt.on_conflict_do_update(
+            index_elements=[self._table.c.source, self._table.c.target],
+            index_where=self._table.c.deleted_at.is_(None),
+            set_={"score": stmt.excluded.score},
+            where=self._table.c.judgement == Judgement.NO_JUDGEMENT.value,
         )
+        self._session.execute(stmt)
+        return edge.target
 
     def decide(
         self,

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -50,10 +50,7 @@ class Resolver(Linker[SE]):
         self._session = session
         # The initial load only needs active edges.
         self._max_ts: Optional[str] = None
-        # In-memory indexes, both pure functions of the table refreshed by
-        # _update_from_db: the positive-merge cluster map that answers the hot
-        # reads, and a raw-keyed cache of blocking (negative/unsure) judgements.
-        # No full edge graph is held — suggestions live only in the table.
+        # Suggestions remain in the table; hot reads use these derived indexes.
         self._linker: Linker[SE] = Linker({})
         self._blockers: Dict[Pair, Judgement] = {}
 
@@ -116,15 +113,10 @@ class Resolver(Linker[SE]):
         self._max_ts = max_ts
 
     def _update_from_db(self) -> None:
-        """Refresh the indexes from edges written since the last load.
+        """Apply this session's recent writes to the indexes.
 
-        Additive deltas (new positive merges, new blockers) fold straight in.
-        A soft-deleted positive edge can split a cluster, which the flat map
-        can't undo in place, so any such removal triggers a full rebuild;
-        deleted blockers are simply dropped. The window is inclusive
-        (``>= _max_ts``) and every apply is idempotent, so an edge written in
-        the same instant as the high-water mark is never missed nor double-
-        counted. Reads its own uncommitted writes via the shared connection.
+        Removing a positive edge may split a cluster and requires a full rebuild.
+        Use ``load_into_memory`` to pick up writes from other sessions.
         """
         if self._max_ts is None:
             self._load_all()
@@ -346,8 +338,7 @@ class Resolver(Linker[SE]):
         score: Optional[float] = None,
     ) -> Identifier:
         result = self._decide(left_id, right_id, judgement, user=user, score=score)
-        # Suggestions don't touch the indexes; everything else does, so refresh
-        # so the caller's next read sees the merge/blocker it just wrote.
+        # Suggestions are not indexed in memory.
         if judgement != Judgement.NO_JUDGEMENT:
             self._update_from_db()
         return result
@@ -360,12 +351,9 @@ class Resolver(Linker[SE]):
         user: Optional[str] = None,
         score: Optional[float] = None,
     ) -> Identifier:
-        """Write a judgement to the table without refreshing the indexes.
+        """Write a judgement without refreshing the indexes.
 
-        Recurses to canonicalise positive matches; the public ``decide``
-        refreshes once at the end. The recursion only ever reads the endpoints
-        it is given against a fresh canonical, so the stale-during-recursion
-        index is never consulted for an edge written earlier in the same call.
+        Used recursively so ``decide`` can refresh once after canonicalisation.
         """
         edge = self.get_edge(left_id, right_id)
         if edge is None:
@@ -452,14 +440,10 @@ class Resolver(Linker[SE]):
         cleanup_after: timedelta = timedelta(days=6 * 30),
         user: Optional[str] = None,
     ) -> None:
-        """Drop suggestions and simplify the merge graph, then refresh.
+        """Drop suggestions and simplify the merge graph.
 
-        Three independent passes: discard NO_JUDGEMENT suggestions, redirect
-        positive edges that still point at a raw id onto their canonical, and
-        collapse old canonical-to-canonical intermediate merges. All three are
-        canonical-preserving — no node changes which cluster it resolves to —
-        so ``get_canonical`` stays valid against the pre-prune index throughout,
-        and a single refresh at the end rebuilds the simplified graph.
+        Rewrites preserve cluster membership, allowing one refresh after all
+        pruning passes complete.
         """
         self._prune_suggestions(user=user)
         self._prune_noncanonical_targets()
@@ -486,16 +470,10 @@ class Resolver(Linker[SE]):
         self._session.execute(stmt)
 
     def _prune_noncanonical_targets(self) -> None:
-        """Replace raw positive merge links with edges onto the canonical.
+        """Replace raw positive merge links with canonical links.
 
-        A positive edge whose target is a raw id bridges two members — e.g. a
-        member-to-member link that merged two existing clusters. Rewriting only
-        one endpoint onto the canonical can drop that bridge and split the
-        cluster when the endpoint already resolves to the winning canonical, so
-        attach *both* endpoints: connectivity is preserved whichever canonical
-        wins, and neither replacement edge has a raw target. The rewrites are
-        canonical-preserving, so ``get_canonical`` stays valid for the rest of
-        the pass against the pre-prune index.
+        Attach both endpoints to avoid splitting a cluster when one already
+        resolves to the winning canonical.
         """
         now = timestamp()
         positive = self._table.c.judgement == Judgement.POSITIVE.value

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
     Table,
     Unicode,
     or_,
+    select,
     text,
 )
 from sqlalchemy.sql.expression import delete, insert, update
@@ -52,7 +53,7 @@ class Resolver(Linker[SE]):
         self._max_ts: Optional[str] = None
         # Suggestions remain in the table; hot reads use these derived indexes.
         self._linker: Linker[SE] = Linker({})
-        self._blockers: Dict[Pair, Judgement] = {}
+        self._blockers: Dict[Tuple[str, str], Judgement] = {}
 
         unique_kw: Dict[str, Any] = {"unique": True}
         if session.is_sqlite:
@@ -88,27 +89,32 @@ class Resolver(Linker[SE]):
         if create:
             session.create(self._table)
 
-    def _index_edge(self, edge: Edge) -> None:
-        """Fold a single live edge into the in-memory indexes."""
-        if edge.judgement == Judgement.POSITIVE:
-            self._linker.add(edge.source.id, edge.target.id)
-        elif edge.judgement in (Judgement.NEGATIVE, Judgement.UNSURE):
-            self._blockers[edge.key] = edge.judgement
+    def _index_row(self, target: str, source: str, judgement: Judgement) -> None:
+        """Fold a live database row into the in-memory indexes."""
+        if judgement == Judgement.POSITIVE:
+            self._linker.add(source, target)
+        elif judgement in (Judgement.NEGATIVE, Judgement.UNSURE):
+            self._blockers[(target, source)] = judgement
 
     def _load_all(self) -> None:
         """Rebuild both indexes from scratch over every live edge."""
         self._linker = Linker({})
         self._blockers = {}
         max_ts: Optional[str] = None
-        stmt = self._table.select().where(self._table.c.deleted_at.is_(None))
+        stmt = select(
+            self._table.c.target,
+            self._table.c.source,
+            self._table.c.judgement,
+            self._table.c.created_at,
+        ).where(self._table.c.deleted_at.is_(None))
         cursor = self._session.execute(stmt)
         while batch := cursor.fetchmany(10000):
             for row in batch:
-                edge = Edge.from_dict(row._mapping)
-                if edge.created_at is not None:
-                    if max_ts is None or edge.created_at > max_ts:
-                        max_ts = edge.created_at
-                self._index_edge(edge)
+                target, source, judgement_, created_at = row
+                if created_at is not None:
+                    if max_ts is None or created_at > max_ts:
+                        max_ts = created_at
+                self._index_row(target, source, Judgement(judgement_))
         cursor.close()
         self._max_ts = max_ts
 
@@ -121,7 +127,13 @@ class Resolver(Linker[SE]):
         if self._max_ts is None:
             self._load_all()
             return
-        stmt = self._table.select().where(
+        stmt = select(
+            self._table.c.target,
+            self._table.c.source,
+            self._table.c.judgement,
+            self._table.c.created_at,
+            self._table.c.deleted_at,
+        ).where(
             or_(
                 self._table.c.created_at >= self._max_ts,
                 self._table.c.deleted_at >= self._max_ts,
@@ -132,18 +144,19 @@ class Resolver(Linker[SE]):
         needs_rebuild = False
         while batch := cursor.fetchmany(10000):
             for row in batch:
-                edge = Edge.from_dict(row._mapping)
-                if edge.created_at is not None and edge.created_at > max_ts:
-                    max_ts = edge.created_at
-                if edge.deleted_at is not None:
-                    if edge.deleted_at > max_ts:
-                        max_ts = edge.deleted_at
-                    if edge.judgement == Judgement.POSITIVE:
+                target, source, judgement_, created_at, deleted_at = row
+                judgement = Judgement(judgement_)
+                if created_at is not None and created_at > max_ts:
+                    max_ts = created_at
+                if deleted_at is not None:
+                    if deleted_at > max_ts:
+                        max_ts = deleted_at
+                    if judgement == Judgement.POSITIVE:
                         needs_rebuild = True
                     else:
-                        self._blockers.pop(edge.key, None)
+                        self._blockers.pop((target, source), None)
                 else:
-                    self._index_edge(edge)
+                    self._index_row(target, source, judgement)
         cursor.close()
         if needs_rebuild:
             self._load_all()
@@ -233,25 +246,27 @@ class Resolver(Linker[SE]):
 
     def get_judgement(self, entity_id: StrIdent, other_id: StrIdent) -> Judgement:
         """Get the existing decision between two entities with dedupe factored in."""
-        entity = Identifier.get(entity_id)
-        other = Identifier.get(other_id)
+        entity = str(entity_id)
+        other = str(other_id)
         if entity == other:
             return Judgement.POSITIVE
-        entity_connected = self.connected(entity)
+        entity_connected = self._linker.connected_ids(entity)
         if other in entity_connected:
             return Judgement.POSITIVE
         # Check QIDs after connected because we sometimes insert an edge to say
         # one QID is canonical for another. Not common but important.
-        if is_qid(entity.id) and is_qid(other.id):
+        if is_qid(entity) and is_qid(other):
             return Judgement.NEGATIVE
 
         # Any blocking (negative/unsure) edge spanning the two clusters decides
         # the pair. A positive edge can't span them — it would have merged the
         # clusters above — so only blockers remain to check.
-        other_connected = self.connected(other)
+        other_connected = self._linker.connected_ids(other)
         for e in entity_connected:
             for o in other_connected:
-                judgement = self._blockers.get(Identifier.pair(e, o))
+                judgement = self._blockers.get((e, o))
+                if judgement is None:
+                    judgement = self._blockers.get((o, e))
                 if judgement is not None:
                     return judgement
 

--- a/nomenklatura/tui/__init__.py
+++ b/nomenklatura/tui/__init__.py
@@ -7,6 +7,7 @@ from nomenklatura.store import Store
 from nomenklatura.tui.dedupe import DedupeApp, DedupeState
 from nomenklatura.tui.reconcile import ReconcileApp, ReconcileState
 from nomenklatura.matching import ScoringAlgorithm
+from nomenklatura.db import Session
 from nomenklatura.resolver import Resolver
 from nomenklatura.wikidata.client import WikidataClient
 from nomenklatura.wikidata.reconcile import prepare_review
@@ -25,6 +26,7 @@ def dedupe_ui(
 
 def reconcile_ui(
     resolver: Resolver[SE],
+    session: Session,
     store: Store[DS, SE],
     client: WikidataClient,
     dataset: Dataset,
@@ -45,6 +47,7 @@ def reconcile_ui(
     # Fetch and rank everything before the TUI boots, with logging on screen.
     items, commands = prepare_review(
         resolver,
+        session,
         store,
         client,
         dataset,

--- a/nomenklatura/tui/__init__.py
+++ b/nomenklatura/tui/__init__.py
@@ -40,14 +40,7 @@ def reconcile_ui(
     user: Optional[str] = None,
     url_base: Optional[str] = None,
 ) -> List[QSCommand]:
-    """Run the interactive Wikidata reconciliation UI; return the queued QS commands.
-
-    All candidates are fetched, scored and sorted up front (with logging
-    visible), then each unlinked person is presented against its ranked Wikidata
-    candidates for a human decision (confirm / no-match / unsure / create / skip).
-    Returns the accumulated QuickStatements commands for the caller to serialize.
-    """
-    # Fetch and rank everything before the TUI boots, with logging on screen.
+    """Review pre-ranked Wikidata candidates and return queued commands."""
     items, commands = prepare_review(
         resolver,
         session,

--- a/nomenklatura/tui/__init__.py
+++ b/nomenklatura/tui/__init__.py
@@ -17,10 +17,13 @@ __all__ = ["dedupe_ui", "reconcile_ui"]
 
 
 def dedupe_ui(
-    resolver: Resolver[SE], store: Store[DS, SE], url_base: Optional[str] = None
+    resolver: Resolver[SE],
+    session: Session,
+    store: Store[DS, SE],
+    url_base: Optional[str] = None,
 ) -> None:
     app = DedupeApp[DS, SE]()
-    app.dedupe = DedupeState(resolver, store, url_base=url_base)
+    app.dedupe = DedupeState(session, resolver, store, url_base=url_base)
     app.run()
 
 
@@ -58,6 +61,7 @@ def reconcile_ui(
     )
     app = ReconcileApp[DS, SE]()
     app.reconcile = ReconcileState(
+        session,
         resolver,
         store,
         dataset,

--- a/nomenklatura/tui/dedupe.py
+++ b/nomenklatura/tui/dedupe.py
@@ -11,6 +11,7 @@ from textual.widgets import Button, Footer, Label, ListItem, ListView, Static
 
 from followthemoney import DS, SE, Dataset, StatementEntity
 
+from nomenklatura.db import Session
 from nomenklatura.judgement import Judgement
 from nomenklatura.resolver import Resolver
 from nomenklatura.resolver.edge import Edge
@@ -23,10 +24,12 @@ HISTORY_LENGTH = 20
 class DedupeState(Generic[DS, SE]):
     def __init__(
         self,
+        session: Session,
         resolver: Resolver[SE],
         store: Store[DS, SE],
         url_base: Optional[str] = None,
     ):
+        self.session = session
         self.store = store
         self.resolver = resolver
         self.view = store.default_view(external=True)
@@ -42,7 +45,7 @@ class DedupeState(Generic[DS, SE]):
     def load(self) -> bool:
         self.left = None
         self.right = None
-        self.resolver.begin()
+        self.resolver.load_into_memory()
         for left_id, right_id, score in self.resolver.get_candidates():
             left_id = self.resolver.get_canonical(left_id)
             right_id = self.resolver.get_canonical(right_id)
@@ -78,14 +81,14 @@ class DedupeState(Generic[DS, SE]):
                     judgement=judgement,
                 )
                 self.store.update(canonical.id)
-        self.resolver.commit()
+        self.session.checkpoint()
         self.load()
 
     def edit(self, edge: Edge, judgement: Judgement) -> None:
         self.resolver.decide(edge.source, edge.target, judgement)
         self.store.update(edge.source.id)
         self.store.update(edge.target.id)
-        self.resolver.commit()
+        self.session.checkpoint()
         self.load()
 
 

--- a/nomenklatura/tui/dedupe.py
+++ b/nomenklatura/tui/dedupe.py
@@ -45,7 +45,6 @@ class DedupeState(Generic[DS, SE]):
     def load(self) -> bool:
         self.left = None
         self.right = None
-        self.resolver.load_into_memory()
         for left_id, right_id, score in self.resolver.get_candidates():
             left_id = self.resolver.get_canonical(left_id)
             right_id = self.resolver.get_canonical(right_id)

--- a/nomenklatura/tui/reconcile.py
+++ b/nomenklatura/tui/reconcile.py
@@ -9,6 +9,7 @@ from textual.widgets import DataTable, Footer
 
 from followthemoney import DS, SE, Dataset, StatementEntity, registry
 
+from nomenklatura.db import Session
 from nomenklatura.judgement import Judgement
 from nomenklatura.resolver import Resolver
 from nomenklatura.store import Store
@@ -35,6 +36,7 @@ class ReconcileState(Generic[DS, SE]):
 
     def __init__(
         self,
+        session: Session,
         resolver: Resolver[SE],
         store: Store[DS, SE],
         dataset: Dataset,
@@ -45,6 +47,7 @@ class ReconcileState(Generic[DS, SE]):
         user: Optional[str] = None,
         url_base: Optional[str] = None,
     ) -> None:
+        self.session = session
         self.resolver = resolver
         self.store = store
         self.dataset = dataset
@@ -71,7 +74,7 @@ class ReconcileState(Generic[DS, SE]):
         return self.highlight >= len(self.candidates)
 
     def start(self) -> bool:
-        self.resolver.begin()
+        self.resolver.load_into_memory()
         return self.load()
 
     def load(self) -> bool:
@@ -110,7 +113,12 @@ class ReconcileState(Generic[DS, SE]):
                 self.person.id, item.id
             ):
                 apply_judgement(
-                    self.resolver, self.store, self.person.id, item.id, Judgement.POSITIVE
+                    self.session,
+                    self.resolver,
+                    self.store,
+                    self.person.id,
+                    item.id,
+                    Judgement.POSITIVE,
                 )
                 positions = position_claims(self.view, self.person)
                 self.commands.extend(
@@ -118,8 +126,6 @@ class ReconcileState(Generic[DS, SE]):
                         self.person, item, self.retrieved, self.source_url, positions
                     )
                 )
-                # apply_judgement committed the transaction; reopen for the next read.
-                self.resolver.begin()
         self.load()
 
     def reject(self, judgement: Judgement) -> None:
@@ -135,9 +141,8 @@ class ReconcileState(Generic[DS, SE]):
         item = self.candidates[self.highlight][0]
         if item.id is not None:
             apply_judgement(
-                self.resolver, self.store, self.person.id, item.id, judgement
+                self.session, self.resolver, self.store, self.person.id, item.id, judgement
             )
-            self.resolver.begin()
         del self.candidates[self.highlight]
         if self.highlight > len(self.candidates):
             self.highlight = len(self.candidates)

--- a/nomenklatura/tui/reconcile.py
+++ b/nomenklatura/tui/reconcile.py
@@ -23,16 +23,7 @@ from nomenklatura.wikidata.write import QSCommand
 
 
 class ReconcileState(Generic[DS, SE]):
-    """Drives the interactive review over a precomputed list of ranked candidates.
-
-    All searching/fetching/scoring happens before the app boots (see
-    `prepare_review`); this state just walks the resulting `ReviewItem`s in
-    memory. A confirmed candidate records a POSITIVE judgement and queues
-    enrichment; "none of the above" queues item creation; no-match/unsure record
-    that judgement and drop the candidate; skip does neither. `commands` is
-    seeded with the already-linked persons' enrichment and grown by both
-    confirms and creates; it is serialized after the app exits.
-    """
+    """Manage interactive review of pre-ranked Wikidata candidates."""
 
     def __init__(
         self,
@@ -60,12 +51,9 @@ class ReconcileState(Generic[DS, SE]):
         self.items = items
         self._index = -1
         self.person: Optional[SE] = None
-        # Ranked candidates for the current person: (item, score, display proxy).
         self.candidates: List[Tuple[Item, float, StatementEntity]] = []
-        # Index into candidates; == len(candidates) means the "none of the above" row.
+        # The index after the last candidate represents "none of the above".
         self.highlight = 0
-        # Seeded with enrichment for already-linked persons; confirms and creates
-        # both append here, and the whole list is serialized on exit.
         self.commands: List[QSCommand] = list(commands or [])
 
     @property
@@ -87,8 +75,7 @@ class ReconcileState(Generic[DS, SE]):
             item = self.items[self._index]
             if item.person.id is None:
                 continue
-            # Re-check against live resolver state: a QID matched earlier this
-            # session may no longer be an eligible candidate.
+            # Earlier decisions may have invalidated a prepared candidate.
             candidates = [
                 candidate
                 for candidate in item.candidates
@@ -129,13 +116,7 @@ class ReconcileState(Generic[DS, SE]):
         self.load()
 
     def reject(self, judgement: Judgement) -> None:
-        """Record a non-positive judgement on the highlighted candidate; drop it.
-
-        Used for "no match" (NEGATIVE) and "unsure": the judgement is written so
-        the pair is never suggested again (now or on a later run), and the
-        candidate leaves the list without advancing to the next person — so you
-        can cull wrong suggestions and then confirm or create.
-        """
+        """Reject the highlighted candidate without advancing the person."""
         if self.person is None or self.person.id is None or self.at_create:
             return
         item = self.candidates[self.highlight][0]
@@ -187,9 +168,7 @@ class CandidateTable(DataTable[Text]):
 
 
 class ComparePanel(VerticalScroll):
-    # Not focusable: otherwise it steals keyboard focus from the candidate list
-    # (its long content makes it scrollable), leaving the arrow keys scrolling
-    # the comparison instead of moving the highlight. Mouse wheel still scrolls.
+    # Keep arrow-key navigation on the candidate table.
     can_focus = False
 
 
@@ -199,9 +178,6 @@ class CompareWidget(ReconcileAppWidget):
         if state.person is None:
             return Text("No more persons to reconcile. Press Q to quit.", justify="center")
         if state.at_create:
-            # Preview what creating a new item would write, in the same table
-            # shape as a candidate — the person on the left, the proposed new
-            # item on the right.
             preview = create_preview(state.dataset, state.person)
             return render_comparison(
                 state.view,
@@ -231,9 +207,7 @@ class ReconcileWidget(Widget):
 class ReconcileApp(App[int], Generic[DS, SE]):
     CSS_PATH = "reconcile.tcss"
     reconcile: ReconcileState[DS, SE]
-    # Per table row, the state.highlight it maps to, or None for a non-selectable
-    # informational row (e.g. "no candidates"). Keeps the table-row index and the
-    # state's candidate index decoupled.
+    # Maps table rows to candidate indexes; informational rows map to None.
     _row_highlights: List[Optional[int]] = []
 
     BINDINGS = [

--- a/nomenklatura/tui/util.py
+++ b/nomenklatura/tui/util.py
@@ -30,13 +30,7 @@ def apply_judgement(
     right_id: str,
     judgement: Judgement,
 ) -> str:
-    """Record a judgement between two entity ids and reflect it in the store.
-
-    The `decide → store.update → checkpoint` triad is easy to get wrong (the
-    store must be re-keyed to the new canonical id, and the order matters), so
-    both the dedupe and reconcile UIs route through here. Returns the canonical
-    id the two entities now share.
-    """
+    """Record a judgement and re-key the store before committing it."""
     canonical = resolver.decide(left_id, right_id, judgement=judgement)
     store.update(canonical.id)
     session.checkpoint()

--- a/nomenklatura/tui/util.py
+++ b/nomenklatura/tui/util.py
@@ -1,6 +1,7 @@
 from typing import Generator, Tuple
 from followthemoney import DS, registry, Property, SE
 
+from nomenklatura.db import Session
 from nomenklatura.judgement import Judgement
 from nomenklatura.resolver import Resolver
 from nomenklatura.store import Store
@@ -22,6 +23,7 @@ ALWAYS_SHOW = {"wikipediaUrl"}
 
 
 def apply_judgement(
+    session: Session,
     resolver: Resolver[SE],
     store: Store[DS, SE],
     left_id: str,
@@ -30,14 +32,14 @@ def apply_judgement(
 ) -> str:
     """Record a judgement between two entity ids and reflect it in the store.
 
-    The `decide → store.update → commit` triad is easy to get wrong (the store
-    must be re-keyed to the new canonical id, and the order matters), so both the
-    dedupe and reconcile UIs route through here. Returns the canonical id the two
-    entities now share.
+    The `decide → store.update → checkpoint` triad is easy to get wrong (the
+    store must be re-keyed to the new canonical id, and the order matters), so
+    both the dedupe and reconcile UIs route through here. Returns the canonical
+    id the two entities now share.
     """
     canonical = resolver.decide(left_id, right_id, judgement=judgement)
     store.update(canonical.id)
-    resolver.commit()
+    session.checkpoint()
     return canonical.id
 
 

--- a/nomenklatura/wikidata/reconcile.py
+++ b/nomenklatura/wikidata/reconcile.py
@@ -5,6 +5,7 @@ from followthemoney import Dataset, DS, SE, StatementEntity, registry
 from rigour.ids.wikidata import is_qid
 from rigour.territories import get_territory_by_qid
 
+from nomenklatura.db import Session
 from nomenklatura.judgement import Judgement
 from nomenklatura.resolver import Resolver
 from nomenklatura.store import Store, View
@@ -206,6 +207,7 @@ def rank_candidates(
 
 def iter_persons(
     resolver: Resolver[SE],
+    session: Session,
     store: Store[DS, SE],
     client: WikidataClient,
     dataset: Dataset,
@@ -225,7 +227,7 @@ def iter_persons(
     view = store.default_view()
     for index, entity in enumerate(view.entities()):
         if index and index % CACHE_INTERVAL == 0:
-            client.cache.flush()
+            session.checkpoint()
         if not entity.schema.is_a("Person") or entity.id is None:
             continue
         current = resolver.get_canonical(entity.id)
@@ -265,6 +267,7 @@ class ReviewItem(Generic[SE]):
 
 def prepare_review(
     resolver: Resolver[SE],
+    session: Session,
     store: Store[DS, SE],
     client: WikidataClient,
     dataset: Dataset,
@@ -289,7 +292,7 @@ def prepare_review(
     commands: List[QSCommand] = []
     seen, linked_count = 0, 0
     for entity, linked_item, candidates in iter_persons(
-        resolver, store, client, dataset, algorithm, aliases
+        resolver, session, store, client, dataset, algorithm, aliases
     ):
         if linked_item is not None:
             positions = position_claims(view, entity)
@@ -313,7 +316,7 @@ def prepare_review(
         best = " (best %.3f)" % candidates[0][1] if candidates else ""
         log.info("[%d] %s — %d candidate(s)%s", seen, entity.caption, len(candidates), best)
     resolver.commit()
-    client.cache.flush()
+    session.checkpoint()
     items.sort(key=lambda review: review.top_score, reverse=True)
     log.info("Prepared %d person(s) for review; %d already linked.", len(items), linked_count)
     return items, commands
@@ -321,6 +324,7 @@ def prepare_review(
 
 def reconcile(
     resolver: Resolver[SE],
+    session: Session,
     store: Store[DS, SE],
     client: WikidataClient,
     dataset: Dataset,
@@ -350,7 +354,7 @@ def reconcile(
     commands: List[QSCommand] = []
     seen, merged = 0, 0
     for entity, linked_item, candidates in iter_persons(
-        resolver, store, client, dataset, algorithm, aliases
+        resolver, session, store, client, dataset, algorithm, aliases
     ):
         if linked_item is not None:
             positions = position_claims(view, entity)

--- a/nomenklatura/wikidata/reconcile.py
+++ b/nomenklatura/wikidata/reconcile.py
@@ -286,7 +286,7 @@ def prepare_review(
     to. The TUI then runs purely in memory. `source_url` is a fallback citation
     for entities lacking their own.
     """
-    resolver.begin()
+    resolver.load_into_memory()
     view = store.default_view()
     items: List[ReviewItem[SE]] = []
     commands: List[QSCommand] = []
@@ -315,7 +315,6 @@ def prepare_review(
         items.append(ReviewItem(entity, candidates))
         best = " (best %.3f)" % candidates[0][1] if candidates else ""
         log.info("[%d] %s — %d candidate(s)%s", seen, entity.caption, len(candidates), best)
-    resolver.commit()
     session.checkpoint()
     items.sort(key=lambda review: review.top_score, reverse=True)
     log.info("Prepared %d person(s) for review; %d already linked.", len(items), linked_count)
@@ -349,7 +348,7 @@ def reconcile(
     This is the headless half of the reconcile tool: no UI, just xref-style
     auto-merge plus reviewable QS.
     """
-    resolver.begin()
+    resolver.load_into_memory()
     view = store.default_view()
     commands: List[QSCommand] = []
     seen, merged = 0, 0
@@ -383,6 +382,6 @@ def reconcile(
         elif create:
             # No acceptable match: propose a new Wikidata item for review.
             commands.extend(propose_create(entity, retrieved, source_url))
-    resolver.commit()
+    session.checkpoint()
     log.info("Reconciled %d of %d unlinked persons to Wikidata.", merged, seen)
     return commands

--- a/nomenklatura/wikidata/reconcile.py
+++ b/nomenklatura/wikidata/reconcile.py
@@ -28,14 +28,10 @@ from nomenklatura.wikidata.write import QSCommand
 
 log = logging.getLogger(__name__)
 
-# How often to commit the API-response cache. Each person triggers several
-# (slow) Wikidata calls, so a long run that's cancelled would otherwise lose
-# every cached response; flushing periodically keeps the work that's done.
+# Bound cache loss when a long reconciliation is interrupted.
 CACHE_INTERVAL = 10
 
-# How many top-ranked candidates per person get Wikipedia summaries fetched for
-# review. Summaries are reviewer context only (the matcher ignores them), so we
-# limit the per-person REST cost to the handful a reviewer actually compares.
+# Summaries are display-only, so fetch them only for likely candidates.
 REVIEW_SUMMARY_CANDIDATES = 5
 
 
@@ -214,15 +210,7 @@ def iter_persons(
     algorithm: Type[ScoringAlgorithm],
     aliases: bool = False,
 ) -> Iterator[Tuple[SE, Optional[Item], List[Tuple[Item, float, StatementEntity]]]]:
-    """Walk persons once, classifying each for the headless and review paths.
-
-    Yields one tuple per Person: an already-linked person as `(entity, item, [])`
-    so the caller can enrich it, and an unlinked person as `(entity, None,
-    candidates)` where candidates are scored, best-first, and already filtered
-    against existing judgements. This is the shared walk — iteration, cache
-    flushing, linked-detection and ranking — leaving enrichment, judgements, QS
-    emission and the resolver transaction to the caller.
-    """
+    """Yield linked items or ranked candidates for each person."""
     config = algorithm.default_config()
     view = store.default_view()
     for index, entity in enumerate(view.entities()):
@@ -231,8 +219,6 @@ def iter_persons(
         if not entity.schema.is_a("Person") or entity.id is None:
             continue
         current = resolver.get_canonical(entity.id)
-        # Linked by a resolver merge (canonical is a QID) or by the entity's own
-        # QID (id or wikidataId property): hand it back for enrichment.
         linked = current if is_qid(current) else entity_qid(entity)
         if linked is not None:
             item = client.fetch_item(linked)
@@ -245,7 +231,6 @@ def iter_persons(
         ):
             if cand_item.id is None:
                 continue
-            # Drop candidates already judged (negative/unsure/positive).
             if not resolver.check_candidate(current, cand_item.id):
                 continue
             candidates.append((cand_item, score, proxy))
@@ -276,16 +261,7 @@ def prepare_review(
     retrieved: Optional[str] = None,
     source_url: Optional[str] = None,
 ) -> Tuple[List["ReviewItem[SE]"], List[QSCommand]]:
-    """Fetch and rank every person's candidates up front, before the TUI.
-
-    Reach for this to drive the interactive review without per-screen network
-    stalls: it does all the searching, fetching and scoring here — with normal
-    logging visible — enriches already-linked persons, and returns the review
-    items sorted by descending top-candidate score together with the
-    linked-person enrichment commands the reviewer's own decisions get appended
-    to. The TUI then runs purely in memory. `source_url` is a fallback citation
-    for entities lacking their own.
-    """
+    """Prepare ranked candidates and linked-person enrichments for review."""
     resolver.load_into_memory()
     view = store.default_view()
     items: List[ReviewItem[SE]] = []
@@ -302,10 +278,6 @@ def prepare_review(
             linked_count += 1
             continue
         seen += 1
-        # Attach Wikipedia summaries to the top candidates so the reviewer sees
-        # who each item is. Fetched here (not in candidate_proxy) because it's a
-        # per-candidate REST call the matcher doesn't need: only the few
-        # candidates a reviewer compares are worth the calls.
         langs = preferred_langs(entity)
         for cand_item, _, proxy in candidates[:REVIEW_SUMMARY_CANDIDATES]:
             for summary in item_wikipedia_summaries(
@@ -335,19 +307,7 @@ def reconcile(
     retrieved: Optional[str] = None,
     source_url: Optional[str] = None,
 ) -> List[QSCommand]:
-    """Match the persons in a store against Wikidata, auto-merge, and emit QS.
-
-    For each person: those already linked to a QID are diffed against their
-    Wikidata item into enrichment commands; those matched above the threshold are
-    recorded as POSITIVE judgements but *not* enriched (an auto-merge is a guess,
-    and we only push edits from links we already trust — they enrich on a later
-    pass once linked); those with no acceptable match become item-creation
-    commands — but only when `create` is set, since a headless create is a
-    speculative new item for every miss, not a human decision; leave it off to
-    emit enrichments alone. Returns the QuickStatements commands to serialize.
-    This is the headless half of the reconcile tool: no UI, just xref-style
-    auto-merge plus reviewable QS.
-    """
+    """Reconcile persons automatically and return QuickStatements commands."""
     resolver.load_into_memory()
     view = store.default_view()
     commands: List[QSCommand] = []
@@ -362,16 +322,12 @@ def reconcile(
             )
             continue
         seen += 1
-        # candidates are already filtered against existing judgements, so the top
-        # one is mergeable; we only re-check the score against the threshold.
         best_item: Optional[Item] = None
         best_score = 0.0
         if candidates:
             best_item, best_score, _ = candidates[0]
         if best_item is not None and best_score > threshold:
-            # Record the link, but don't enrich off it: an auto-merge is an
-            # unconfirmed guess, and we only push Wikidata edits from links we
-            # already trust. It gets enriched on a later pass as "already linked".
+            # Only established links are trusted as sources for Wikidata edits.
             log.info("Auto-merge [%.3f]: %s <> %s", best_score, entity.id, best_item.id)
             assert entity.id is not None  # iter_persons never yields id-less entities
             canonical = resolver.decide(
@@ -380,7 +336,6 @@ def reconcile(
             store.update(canonical.id)
             merged += 1
         elif create:
-            # No acceptable match: propose a new Wikidata item for review.
             commands.extend(propose_create(entity, retrieved, source_url))
     session.checkpoint()
     log.info("Reconciled %d of %d unlinked persons to Wikidata.", merged, seen)

--- a/nomenklatura/xref.py
+++ b/nomenklatura/xref.py
@@ -68,6 +68,10 @@ def xref(
         suggested = 0
         idx = 0
         resolver.load_into_memory()
+        # Release the load's read transaction before the scan: all the reads in
+        # the loop (get_canonical/check_candidate) are in-memory, so nothing
+        # needs to hold a transaction open until the first suggestion is written.
+        session.checkpoint()
         pairs = index.pairs(max_pairs=max_pairs)
         for idx, ((left_id_, right_id_), score) in enumerate(pairs):
             if idx % 1000 == 0 and idx > 0:

--- a/nomenklatura/xref.py
+++ b/nomenklatura/xref.py
@@ -68,9 +68,7 @@ def xref(
         suggested = 0
         idx = 0
         resolver.load_into_memory()
-        # Release the load's read transaction before the scan: all the reads in
-        # the loop (get_canonical/check_candidate) are in-memory, so nothing
-        # needs to hold a transaction open until the first suggestion is written.
+        # Release the load transaction before the in-memory scan.
         session.checkpoint()
         pairs = index.pairs(max_pairs=max_pairs)
         for idx, ((left_id_, right_id_), score) in enumerate(pairs):

--- a/nomenklatura/xref.py
+++ b/nomenklatura/xref.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Type
 from followthemoney import Schema, DS, SE
 from pathlib import Path
 
+from nomenklatura.db import Session
 from nomenklatura.store import Store
 from nomenklatura.judgement import Judgement
 from nomenklatura.resolver import Resolver
@@ -26,6 +27,7 @@ def _print_stats(pairs: int, suggested: int, scores: List[float]) -> None:
 
 def xref(
     resolver: Resolver[SE],
+    session: Session,
     store: Store[DS, SE],
     index_dir: Path,
     limit: int = 5000,
@@ -65,7 +67,7 @@ def xref(
         scores: List[float] = []
         suggested = 0
         idx = 0
-        resolver.begin()
+        resolver.load_into_memory()
         pairs = index.pairs(max_pairs=max_pairs)
         for idx, ((left_id_, right_id_), score) in enumerate(pairs):
             if idx % 1000 == 0 and idx > 0:
@@ -84,8 +86,7 @@ def xref(
                 break
 
             if suggested % 10000 == 0 and suggested > 0:
-                resolver.commit()
-                resolver.begin()
+                session.checkpoint()
 
             left_id = resolver.get_canonical(left_id_.id)
             right_id = resolver.get_canonical(right_id_.id)
@@ -148,7 +149,7 @@ def xref(
                 break
             suggested += 1
         _print_stats(idx, suggested, scores)
-        resolver.commit()
+        session.checkpoint()
     except KeyboardInterrupt:
         log.info("User cancelled, xref will end gracefully.")
     finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import json
 import shutil
 from typing import Any, Callable, Dict, Generator, List
-from sqlalchemy import MetaData
 import yaml
 import pytest
 from urllib.error import HTTPError
@@ -67,26 +66,18 @@ def donations_json(donations_path: Path) -> List[Dict[str, Any]]:
 
 
 @pytest.fixture(scope="function")
-def resolver() -> Generator[Resolver[Entity], None, None]:
-    resolver = Resolver[Entity].make_default()
-    yield resolver
-    resolver.close()
-    resolver._table.drop(resolver._engine, checkfirst=True)
+def resolver(db_session: Session) -> Resolver[Entity]:
+    return Resolver[Entity](db_session, create=True)
 
 
 @pytest.fixture(scope="function")
-def other_table_resolver():
-    engine = get_engine()
-    meta = MetaData()
-    resolver = Resolver(engine, meta, create=True, table_name="another_table")
-    yield resolver
-    resolver.rollback()
-    resolver._table.drop(engine)
+def other_table_resolver(db_session: Session) -> Resolver[Entity]:
+    return Resolver(db_session, create=True, table_name="another_table")
 
 
 @pytest.fixture(scope="function")
 def dstore(donations_path: Path, resolver: Resolver[Entity]) -> SimpleMemoryStore:
-    resolver.begin()
+    resolver.load_into_memory()
     return load_entity_file_store(donations_path, resolver)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,11 +33,7 @@ def wrap_test():
     if settings.DB_URL.startswith("sqlite"):
         settings.DB_URL = "sqlite:///:memory:"
     yield
-    # Drop every table, reflecting the live schema rather than a single
-    # MetaData: Cache and Resolver now own per-instance MetaData, so a global
-    # drop_all would miss their tables and leak committed rows across tests on
-    # a persistent Postgres. (On in-memory sqlite the engine is disposed below
-    # anyway, but reflecting is harmless there.)
+    # Reflect so per-instance metadata tables are dropped between tests.
     engine = get_engine()
     meta = MetaData()
     meta.reflect(bind=engine)
@@ -93,12 +89,7 @@ def test_dataset() -> Dataset:
 
 @pytest.fixture(scope="function")
 def db_session() -> Generator[Session, None, None]:
-    """One unit-of-work session per test, disposed on teardown.
-
-    Mirrors the production ownership model (the test is the owner) and, more
-    importantly, guarantees the connection is released — no test can leak an
-    open transaction into the next.
-    """
+    """Yield one unit-of-work session per test."""
     session = make_session()
     try:
         yield session
@@ -113,11 +104,7 @@ def test_cache(db_session: Session, test_dataset: Dataset) -> Cache:
 
 @pytest.fixture(scope="function")
 def cache_factory(db_session: Session) -> Callable[[Dataset], Cache]:
-    """Build a cache for an arbitrary dataset on the per-test session.
-
-    Replaces the old ``Cache.make_default`` in tests that need a cache for a
-    dataset other than ``test_dataset`` (wikidata, enrichers, ...).
-    """
+    """Build caches for arbitrary datasets on the per-test session."""
     return lambda dataset: Cache(db_session, dataset, create=True)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import json
 import shutil
-from typing import Any, Dict, Generator, List
+from typing import Any, Callable, Dict, Generator, List
 from sqlalchemy import MetaData
 import yaml
 import pytest
@@ -14,7 +14,7 @@ from followthemoney import Dataset, StatementEntity as Entity
 from nomenklatura import settings
 from nomenklatura.store import load_entity_file_store, SimpleMemoryStore
 from nomenklatura.kv import get_redis
-from nomenklatura.db import close_db, get_engine, get_metadata
+from nomenklatura.db import close_db, get_engine, get_metadata, make_session, Session
 from nomenklatura.resolver import Resolver
 from nomenklatura.blocker.index import Index
 from nomenklatura.cache import Cache
@@ -96,12 +96,33 @@ def test_dataset() -> Dataset:
 
 
 @pytest.fixture(scope="function")
-def test_cache(test_dataset: Dataset) -> Generator[Cache, None, None]:
-    engine = get_engine(settings.DB_URL)
-    metadata = get_metadata()
-    cache = Cache(engine, metadata, test_dataset, create=True)
-    yield cache
-    cache.close()
+def db_session() -> Generator[Session, None, None]:
+    """One unit-of-work session per test, disposed on teardown.
+
+    Mirrors the production ownership model (the test is the owner) and, more
+    importantly, guarantees the connection is released — no test can leak an
+    open transaction into the next.
+    """
+    session = make_session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture(scope="function")
+def test_cache(db_session: Session, test_dataset: Dataset) -> Cache:
+    return Cache(db_session, test_dataset, create=True)
+
+
+@pytest.fixture(scope="function")
+def cache_factory(db_session: Session) -> Callable[[Dataset], Cache]:
+    """Build a cache for an arbitrary dataset on the per-test session.
+
+    Replaces the old ``Cache.make_default`` in tests that need a cache for a
+    dataset other than ``test_dataset`` (wikidata, enrichers, ...).
+    """
+    return lambda dataset: Cache(db_session, dataset, create=True)
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,9 @@ from followthemoney import Dataset, StatementEntity as Entity
 from nomenklatura import settings
 from nomenklatura.store import load_entity_file_store, SimpleMemoryStore
 from nomenklatura.kv import get_redis
-from nomenklatura.db import close_db, get_engine, get_metadata, make_session, Session
+from sqlalchemy import MetaData
+
+from nomenklatura.db import close_db, get_engine, make_session, Session
 from nomenklatura.resolver import Resolver
 from nomenklatura.blocker.index import Index
 from nomenklatura.cache import Cache
@@ -31,10 +33,14 @@ def wrap_test():
     if settings.DB_URL.startswith("sqlite"):
         settings.DB_URL = "sqlite:///:memory:"
     yield
-    # Dispose of connections to let open transactions for resources not
-    # managed by the setup/teardown abort.
+    # Drop every table, reflecting the live schema rather than a single
+    # MetaData: Cache and Resolver now own per-instance MetaData, so a global
+    # drop_all would miss their tables and leak committed rows across tests on
+    # a persistent Postgres. (On in-memory sqlite the engine is disposed below
+    # anyway, but reflecting is harmless there.)
     engine = get_engine()
-    meta = get_metadata()
+    meta = MetaData()
+    meta.reflect(bind=engine)
     meta.drop_all(bind=engine)
     close_db()
     get_redis.cache_clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,6 @@ def other_table_resolver(db_session: Session) -> Resolver[Entity]:
 
 @pytest.fixture(scope="function")
 def dstore(donations_path: Path, resolver: Resolver[Entity]) -> SimpleMemoryStore:
-    resolver.load_into_memory()
     return load_entity_file_store(donations_path, resolver)
 
 

--- a/tests/enrich/test_nominatim.py
+++ b/tests/enrich/test_nominatim.py
@@ -87,7 +87,7 @@ def test_nominatim_match(cache_factory):
 
 
 def test_nominatim_match_list(resolver: Resolver[StatementEntity], cache_factory):
-    resolver.begin()
+    resolver.load_into_memory()
     enricher = load_enricher(cache_factory)
 
     full = "Kopenhagener Str. 47, Berlin"
@@ -118,7 +118,7 @@ def test_nominatim_enrich(cache_factory):
 
 
 def test_nominatim_enrich_list(resolver: Resolver[StatementEntity], cache_factory):
-    resolver.begin()
+    resolver.load_into_memory()
     enricher = load_enricher(cache_factory)
 
     full = "Kopenhagener Str. 47, Berlin"

--- a/tests/enrich/test_nominatim.py
+++ b/tests/enrich/test_nominatim.py
@@ -1,6 +1,5 @@
 import requests_mock
 from followthemoney import Dataset, StatementEntity
-from nomenklatura.cache import Cache
 from nomenklatura.enrich import make_enricher, enrich, match, Enricher
 from nomenklatura.judgement import Judgement
 from nomenklatura.resolver import Resolver
@@ -62,13 +61,13 @@ RESPONSE = [
 ]
 
 
-def load_enricher() -> Enricher[Dataset]:
-    cache = Cache.make_default(dataset)
+def load_enricher(cache_factory) -> Enricher[Dataset]:
+    cache = cache_factory(dataset)
     return make_enricher(dataset, cache, {"type": PATH})
 
 
-def test_nominatim_match():
-    enricher = load_enricher()
+def test_nominatim_match(cache_factory):
+    enricher = load_enricher(cache_factory)
     with requests_mock.Mocker(real_http=False) as m:
         m.get("/search.php", json=RESPONSE)
         full = "Kopenhagener Str. 47, Berlin"
@@ -87,9 +86,9 @@ def test_nominatim_match():
     enricher.close()
 
 
-def test_nominatim_match_list(resolver: Resolver[StatementEntity]):
+def test_nominatim_match_list(resolver: Resolver[StatementEntity], cache_factory):
     resolver.begin()
-    enricher = load_enricher()
+    enricher = load_enricher(cache_factory)
 
     full = "Kopenhagener Str. 47, Berlin"
     data = {"schema": "Address", "id": "xxx", "properties": {"full": [full]}}
@@ -106,8 +105,8 @@ def test_nominatim_match_list(resolver: Resolver[StatementEntity]):
     enricher.close()
 
 
-def test_nominatim_enrich():
-    enricher = load_enricher()
+def test_nominatim_enrich(cache_factory):
+    enricher = load_enricher(cache_factory)
     full = "Kopenhagener Str. 47, Berlin"
     data = {"schema": "Address", "id": "xxx", "properties": {"full": [full]}}
     ent = StatementEntity.from_data(dataset, data)
@@ -118,9 +117,9 @@ def test_nominatim_enrich():
     enricher.close()
 
 
-def test_nominatim_enrich_list(resolver: Resolver[StatementEntity]):
+def test_nominatim_enrich_list(resolver: Resolver[StatementEntity], cache_factory):
     resolver.begin()
-    enricher = load_enricher()
+    enricher = load_enricher(cache_factory)
 
     full = "Kopenhagener Str. 47, Berlin"
     data = {"schema": "Address", "id": "xxx", "properties": {"full": [full]}}

--- a/tests/enrich/test_nominatim.py
+++ b/tests/enrich/test_nominatim.py
@@ -87,7 +87,6 @@ def test_nominatim_match(cache_factory):
 
 
 def test_nominatim_match_list(resolver: Resolver[StatementEntity], cache_factory):
-    resolver.load_into_memory()
     enricher = load_enricher(cache_factory)
 
     full = "Kopenhagener Str. 47, Berlin"
@@ -118,7 +117,6 @@ def test_nominatim_enrich(cache_factory):
 
 
 def test_nominatim_enrich_list(resolver: Resolver[StatementEntity], cache_factory):
-    resolver.load_into_memory()
     enricher = load_enricher(cache_factory)
 
     full = "Kopenhagener Str. 47, Berlin"

--- a/tests/enrich/test_openfigi.py
+++ b/tests/enrich/test_openfigi.py
@@ -1,6 +1,5 @@
 import requests_mock
 from followthemoney import Dataset, StatementEntity
-from nomenklatura.cache import Cache
 from nomenklatura.enrich import make_enricher, Enricher
 
 
@@ -38,13 +37,13 @@ RESPONSE = {
 dataset = Dataset.make({"name": "ext_open_figi", "title": "OpenFIGI"})
 
 
-def load_enricher() -> Enricher[Dataset]:
-    cache = Cache.make_default(dataset)
+def load_enricher(cache_factory) -> Enricher[Dataset]:
+    cache = cache_factory(dataset)
     return make_enricher(dataset, cache, {"type": PATH})
 
 
-def test_figi_match():
-    enricher = load_enricher()
+def test_figi_match(cache_factory):
+    enricher = load_enricher(cache_factory)
     with requests_mock.Mocker(real_http=False) as m:
         m.post("/v3/search", json=RESPONSE)
 

--- a/tests/enrich/test_permid.py
+++ b/tests/enrich/test_permid.py
@@ -1,6 +1,5 @@
 import requests_mock
 from followthemoney import Dataset, StatementEntity
-from nomenklatura.cache import Cache
 from nomenklatura.enrich import make_enricher, Enricher
 
 PATH = "nomenklatura.enrich.permid:PermIDEnricher"
@@ -153,13 +152,13 @@ GEONAME = """<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 </rdf:RDF>"""
 
 
-def load_enricher() -> Enricher[Dataset]:
-    cache = Cache.make_default(dataset)
+def load_enricher(cache_factory) -> Enricher[Dataset]:
+    cache = cache_factory(dataset)
     return make_enricher(dataset, cache, {"type": PATH})
 
 
-def test_permid_match():
-    enricher = load_enricher()
+def test_permid_match(cache_factory):
+    enricher = load_enricher(cache_factory)
     with requests_mock.Mocker(real_http=False) as m:
         m.post("/permid/match", json=MATCH_ROSNEFT)
         m.get("https://permid.org/1-4295887083", json=ROSNEFT)
@@ -190,8 +189,8 @@ def test_permid_match():
     enricher.close()
 
 
-def test_permid_enrich():
-    enricher = load_enricher()
+def test_permid_enrich(cache_factory):
+    enricher = load_enricher(cache_factory)
     with requests_mock.Mocker(real_http=False) as m:
         m.post("/permid/match", json=MATCH_ROSNEFT)
         m.get("https://permid.org/1-4295887083", json=ROSNEFT)

--- a/tests/enrich/test_wikidata.py
+++ b/tests/enrich/test_wikidata.py
@@ -1,6 +1,5 @@
 import requests_mock
 from followthemoney import Dataset, StatementEntity
-from nomenklatura.cache import Cache
 from nomenklatura.enrich import make_enricher, Enricher
 
 from ..conftest import wd_read_response
@@ -9,13 +8,13 @@ PATH = "nomenklatura.enrich.wikidata:WikidataEnricher"
 dataset = Dataset.make({"name": "wikidata", "title": "Wikidata"})
 
 
-def load_enricher() -> Enricher[Dataset]:
-    cache = Cache.make_default(dataset)
+def load_enricher(cache_factory) -> Enricher[Dataset]:
+    cache = cache_factory(dataset)
     return make_enricher(dataset, cache, {"type": PATH})
 
 
-def test_wikidata_match():
-    enricher = load_enricher()
+def test_wikidata_match(cache_factory):
+    enricher = load_enricher(cache_factory)
 
     with requests_mock.Mocker(real_http=False) as m:
         m.register_uri(
@@ -50,8 +49,8 @@ def test_wikidata_match():
     enricher.close()
 
 
-def test_wikidata_enrich():
-    enricher = load_enricher()
+def test_wikidata_enrich(cache_factory):
+    enricher = load_enricher(cache_factory)
     with requests_mock.Mocker(real_http=False) as m:
         m.register_uri(
             "GET",

--- a/tests/store/test_leveldb.py
+++ b/tests/store/test_leveldb.py
@@ -24,7 +24,6 @@ PERSON_EXT = {
 def test_leveldb_store_basics(
     test_dataset: Dataset, resolver: Resolver[StatementEntity]
 ):
-    resolver.load_into_memory()
     path = Path(tempfile.mkdtemp()) / "leveldb"
     store = LevelDBStore(test_dataset, resolver, path)
     entity = StatementEntity.from_data(test_dataset, PERSON)
@@ -51,7 +50,6 @@ def test_leveldb_store_basics(
 def test_leveldb_graph_query(
     donations_path: Path, test_dataset: Dataset, resolver: Resolver[StatementEntity]
 ):
-    resolver.load_into_memory()
     path = Path(tempfile.mkdtemp()) / "xxx"
     store = LevelDBStore(test_dataset, resolver, path)
     assert len(list(store.view(test_dataset).entities())) == 0

--- a/tests/store/test_leveldb.py
+++ b/tests/store/test_leveldb.py
@@ -24,7 +24,7 @@ PERSON_EXT = {
 def test_leveldb_store_basics(
     test_dataset: Dataset, resolver: Resolver[StatementEntity]
 ):
-    resolver.begin()
+    resolver.load_into_memory()
     path = Path(tempfile.mkdtemp()) / "leveldb"
     store = LevelDBStore(test_dataset, resolver, path)
     entity = StatementEntity.from_data(test_dataset, PERSON)
@@ -51,7 +51,7 @@ def test_leveldb_store_basics(
 def test_leveldb_graph_query(
     donations_path: Path, test_dataset: Dataset, resolver: Resolver[StatementEntity]
 ):
-    resolver.begin()
+    resolver.load_into_memory()
     path = Path(tempfile.mkdtemp()) / "xxx"
     store = LevelDBStore(test_dataset, resolver, path)
     assert len(list(store.view(test_dataset).entities())) == 0

--- a/tests/store/test_memory.py
+++ b/tests/store/test_memory.py
@@ -21,7 +21,7 @@ PERSON_EXT = {
 
 
 def test_basic_store(test_dataset: Dataset, resolver: Resolver[Entity]):
-    resolver.begin()
+    resolver.load_into_memory()
     store = MemoryStore(test_dataset, resolver)
     entity = Entity.from_data(test_dataset, PERSON)
     entity_ext = Entity.from_data(test_dataset, PERSON_EXT)

--- a/tests/store/test_memory.py
+++ b/tests/store/test_memory.py
@@ -21,7 +21,6 @@ PERSON_EXT = {
 
 
 def test_basic_store(test_dataset: Dataset, resolver: Resolver[Entity]):
-    resolver.load_into_memory()
     store = MemoryStore(test_dataset, resolver)
     entity = Entity.from_data(test_dataset, PERSON)
     entity_ext = Entity.from_data(test_dataset, PERSON_EXT)

--- a/tests/store/test_redis.py
+++ b/tests/store/test_redis.py
@@ -23,7 +23,6 @@ PERSON_EXT = {
 
 
 def test_redis_store_basics(test_dataset: Dataset, resolver: Resolver[Entity]):
-    resolver.load_into_memory()
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
     store = RedisStore(test_dataset, resolver, db=redis)
     entity = Entity.from_data(test_dataset, PERSON)
@@ -50,7 +49,6 @@ def test_redis_store_basics(test_dataset: Dataset, resolver: Resolver[Entity]):
 def test_leveldb_graph_query(
     donations_path: Path, test_dataset: Dataset, resolver: Resolver[Entity]
 ):
-    resolver.load_into_memory()
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
     store = RedisStore(test_dataset, resolver, db=redis)
     assert len(list(store.view(test_dataset).entities())) == 0

--- a/tests/store/test_redis.py
+++ b/tests/store/test_redis.py
@@ -23,7 +23,7 @@ PERSON_EXT = {
 
 
 def test_redis_store_basics(test_dataset: Dataset, resolver: Resolver[Entity]):
-    resolver.begin()
+    resolver.load_into_memory()
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
     store = RedisStore(test_dataset, resolver, db=redis)
     entity = Entity.from_data(test_dataset, PERSON)
@@ -50,7 +50,7 @@ def test_redis_store_basics(test_dataset: Dataset, resolver: Resolver[Entity]):
 def test_leveldb_graph_query(
     donations_path: Path, test_dataset: Dataset, resolver: Resolver[Entity]
 ):
-    resolver.begin()
+    resolver.load_into_memory()
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
     store = RedisStore(test_dataset, resolver, db=redis)
     assert len(list(store.view(test_dataset).entities())) == 0

--- a/tests/store/test_stores.py
+++ b/tests/store/test_stores.py
@@ -79,7 +79,7 @@ def test_store_sql(
     donations_json: List[Dict[str, Any]],
     resolver: Resolver[Entity],
 ):
-    resolver.begin()
+    resolver.load_into_memory()
     uri = f"sqlite:///{tmp_path / 'test.db'}"
     store = SQLStore(dataset=test_dataset, linker=resolver, uri=uri)
     try:
@@ -95,7 +95,7 @@ def test_sql_writer_sqlite_batch_limit_cap(
     resolver: Resolver[Entity],
     monkeypatch: MonkeyPatch,
 ):
-    resolver.begin()
+    resolver.load_into_memory()
     uri = f"sqlite:///{tmp_path / 'test.db'}"
     store = SQLStore(dataset=test_dataset, linker=resolver, uri=uri)
     try:
@@ -113,7 +113,7 @@ def test_sql_writer_sqlite_batch_limit_uses_setting_when_lower(
     resolver: Resolver[Entity],
     monkeypatch: MonkeyPatch,
 ):
-    resolver.begin()
+    resolver.load_into_memory()
     uri = f"sqlite:///{tmp_path / 'test.db'}"
     store = SQLStore(dataset=test_dataset, linker=resolver, uri=uri)
     try:
@@ -138,7 +138,7 @@ def test_store_memory(
     donations_json: List[Dict[str, Any]],
     resolver: Resolver[Entity],
 ):
-    resolver.begin()
+    resolver.load_into_memory()
     store = SimpleMemoryStore(dataset=test_dataset, linker=resolver)
     assert _run_store_test(store, test_dataset, donations_json)
 
@@ -149,7 +149,7 @@ def test_store_level(
     donations_json: List[Dict[str, Any]],
     resolver: Resolver[Entity],
 ):
-    resolver.begin()
+    resolver.load_into_memory()
     path = tmp_path / "level.db"
     store = LevelDBStore(dataset=test_dataset, linker=resolver, path=path)
     assert _run_store_test(store, test_dataset, donations_json)

--- a/tests/store/test_stores.py
+++ b/tests/store/test_stores.py
@@ -79,7 +79,6 @@ def test_store_sql(
     donations_json: List[Dict[str, Any]],
     resolver: Resolver[Entity],
 ):
-    resolver.load_into_memory()
     uri = f"sqlite:///{tmp_path / 'test.db'}"
     store = SQLStore(dataset=test_dataset, linker=resolver, uri=uri)
     try:
@@ -95,7 +94,6 @@ def test_sql_writer_sqlite_batch_limit_cap(
     resolver: Resolver[Entity],
     monkeypatch: MonkeyPatch,
 ):
-    resolver.load_into_memory()
     uri = f"sqlite:///{tmp_path / 'test.db'}"
     store = SQLStore(dataset=test_dataset, linker=resolver, uri=uri)
     try:
@@ -113,7 +111,6 @@ def test_sql_writer_sqlite_batch_limit_uses_setting_when_lower(
     resolver: Resolver[Entity],
     monkeypatch: MonkeyPatch,
 ):
-    resolver.load_into_memory()
     uri = f"sqlite:///{tmp_path / 'test.db'}"
     store = SQLStore(dataset=test_dataset, linker=resolver, uri=uri)
     try:
@@ -138,7 +135,6 @@ def test_store_memory(
     donations_json: List[Dict[str, Any]],
     resolver: Resolver[Entity],
 ):
-    resolver.load_into_memory()
     store = SimpleMemoryStore(dataset=test_dataset, linker=resolver)
     assert _run_store_test(store, test_dataset, donations_json)
 
@@ -149,7 +145,6 @@ def test_store_level(
     donations_json: List[Dict[str, Any]],
     resolver: Resolver[Entity],
 ):
-    resolver.load_into_memory()
     path = tmp_path / "level.db"
     store = LevelDBStore(dataset=test_dataset, linker=resolver, path=path)
     assert _run_store_test(store, test_dataset, donations_json)

--- a/tests/store/test_versioned.py
+++ b/tests/store/test_versioned.py
@@ -24,7 +24,6 @@ PERSON_EXT = {
 
 
 def test_store_basics(test_dataset: Dataset, resolver: Resolver[Entity]):
-    resolver.load_into_memory()
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
     store = VersionedRedisStore(test_dataset, resolver, db=redis)
     assert len(list(store.view(test_dataset).statements())) == 0
@@ -62,7 +61,6 @@ def test_store_basics(test_dataset: Dataset, resolver: Resolver[Entity]):
 def test_graph_query(
     donations_path: Path, test_dataset: Dataset, resolver: Resolver[Entity]
 ):
-    resolver.load_into_memory()
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
     store = VersionedRedisStore(test_dataset, resolver, db=redis)
     assert len(list(store.view(test_dataset).entities())) == 0

--- a/tests/store/test_versioned.py
+++ b/tests/store/test_versioned.py
@@ -24,7 +24,7 @@ PERSON_EXT = {
 
 
 def test_store_basics(test_dataset: Dataset, resolver: Resolver[Entity]):
-    resolver.begin()
+    resolver.load_into_memory()
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
     store = VersionedRedisStore(test_dataset, resolver, db=redis)
     assert len(list(store.view(test_dataset).statements())) == 0
@@ -62,7 +62,7 @@ def test_store_basics(test_dataset: Dataset, resolver: Resolver[Entity]):
 def test_graph_query(
     donations_path: Path, test_dataset: Dataset, resolver: Resolver[Entity]
 ):
-    resolver.begin()
+    resolver.load_into_memory()
     redis = fakeredis.FakeStrictRedis(version=6, decode_responses=False)
     store = VersionedRedisStore(test_dataset, resolver, db=redis)
     assert len(list(store.view(test_dataset).entities())) == 0

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -13,7 +13,6 @@ def test_cache(test_cache: Cache):
     res = test_cache.get("name")
     assert res is not None, res
     assert res == "TestCase", res
-    test_cache.flush()
     assert test_cache.has("name")
 
     res = test_cache.get("name", max_age=5)
@@ -27,12 +26,9 @@ def test_cache(test_cache: Cache):
     test_cache.delete("banana")
     assert not test_cache.has("banana")
 
-    test_cache.close()
-
 
 def test_cache_utils(test_cache: Cache):
     assert hash(test_cache) != 0
-    test_cache.close()
 
 
 def test_preload_cache(test_cache: Cache):
@@ -51,4 +47,3 @@ def test_preload_cache(test_cache: Cache):
 
     res = test_cache.get("name", max_age=5)
     assert res == "TestCase", res
-    test_cache.close()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -30,12 +30,10 @@ def test_session_checkpoint_persists_and_continues(tmp_path: Path):
     session.execute(insert(table).values(key="a", value="1"))
     session.checkpoint()
 
-    # A fresh connection sees the committed row...
     other = make_session(url)
     assert "a" in _keys(other, _kv_table(other))
     other.close()
 
-    # ...and the original session keeps working without a manual begin.
     session.execute(insert(table).values(key="b", value="2"))
     session.commit()
     assert session._conn is None
@@ -77,7 +75,6 @@ def test_session_context_manager_commits_on_clean_exit(tmp_path: Path):
 
 def test_session_context_manager_rolls_back_on_error(tmp_path: Path):
     url = f"sqlite:///{tmp_path / 'kv.db'}"
-    # Create + commit the table first so the rollback below only drops the row.
     setup = make_session(url)
     _kv_table(setup)
     setup.commit()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,9 +1,104 @@
+from pathlib import Path
 from typing import List, Dict, Any, Generator
-from sqlalchemy import MetaData, select
+import pytest
+from sqlalchemy import Column, MetaData, Table, Unicode, insert, select
 from followthemoney import Dataset, Statement, StatementEntity
 
-from nomenklatura.db import get_engine
+from nomenklatura.db import get_engine, make_session, Session
 from nomenklatura.db import make_statement_table, insert_statements
+
+
+def _kv_table(session: Session) -> Table:
+    table = Table(
+        "kv",
+        MetaData(),
+        Column("key", Unicode(), primary_key=True),
+        Column("value", Unicode()),
+    )
+    session.create(table)
+    return table
+
+
+def _keys(session: Session, table: Table) -> List[str]:
+    return [row.key for row in session.execute(select(table.c.key))]
+
+
+def test_session_checkpoint_persists_and_continues(tmp_path: Path):
+    url = f"sqlite:///{tmp_path / 'kv.db'}"
+    session = make_session(url)
+    table = _kv_table(session)
+    session.execute(insert(table).values(key="a", value="1"))
+    session.checkpoint()
+
+    # A fresh connection sees the committed row...
+    other = make_session(url)
+    assert "a" in _keys(other, _kv_table(other))
+    other.close()
+
+    # ...and the original session keeps working without a manual begin.
+    session.execute(insert(table).values(key="b", value="2"))
+    session.commit()
+    assert session._conn is None
+
+
+def test_session_commit_disposes_connection(tmp_path: Path):
+    session = make_session(f"sqlite:///{tmp_path / 'kv.db'}")
+    table = _kv_table(session)
+    conn = session.connection
+    session.execute(insert(table).values(key="a", value="1"))
+    session.commit()
+    assert session._conn is None
+    assert conn.closed
+
+
+def test_session_rollback_discards_but_keeps_connection(tmp_path: Path):
+    session = make_session(f"sqlite:///{tmp_path / 'kv.db'}")
+    table = _kv_table(session)
+    session.checkpoint()  # commit the DDL
+    session.execute(insert(table).values(key="a", value="1"))
+    session.rollback()
+    assert _keys(session, table) == []  # write discarded
+    assert session._conn is not None  # connection still usable
+    session.close()
+
+
+def test_session_context_manager_commits_on_clean_exit(tmp_path: Path):
+    url = f"sqlite:///{tmp_path / 'kv.db'}"
+    with make_session(url) as session:
+        table = _kv_table(session)
+        session.execute(insert(table).values(key="a", value="1"))
+    assert session._conn is None
+
+    verify = make_session(url)
+    vtable = _kv_table(verify)
+    assert _keys(verify, vtable) == ["a"]
+    verify.close()
+
+
+def test_session_context_manager_rolls_back_on_error(tmp_path: Path):
+    url = f"sqlite:///{tmp_path / 'kv.db'}"
+    # Create + commit the table first so the rollback below only drops the row.
+    setup = make_session(url)
+    _kv_table(setup)
+    setup.commit()
+
+    with pytest.raises(RuntimeError):
+        with make_session(url) as session:
+            table = Table("kv", MetaData(), autoload_with=session.connection)
+            session.execute(insert(table).values(key="a", value="1"))
+            raise RuntimeError("boom")
+    assert session._conn is None
+
+    verify = make_session(url)
+    vtable = Table("kv", MetaData(), autoload_with=verify.connection)
+    assert _keys(verify, vtable) == []
+    verify.close()
+
+
+def test_session_dialect(tmp_path: Path):
+    session = make_session(f"sqlite:///{tmp_path / 'kv.db'}")
+    assert session.dialect.name == "sqlite"
+    session.close()
 
 
 def _parse_statements(

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -75,7 +75,7 @@ def _store(tmp_path, resolver, *lines: str):
 
 
 def test_position_claims_dates_and_qid(tmp_path, resolver: Resolver[Entity]):
-    resolver.begin()
+    resolver.load_into_memory()
     store = _store(
         tmp_path,
         resolver,
@@ -95,7 +95,7 @@ def test_position_claims_dates_and_qid(tmp_path, resolver: Resolver[Entity]):
 def test_position_claims_period_fallback_and_skips_unqid(
     tmp_path, resolver: Resolver[Entity]
 ):
-    resolver.begin()
+    resolver.load_into_memory()
     store = _store(
         tmp_path,
         resolver,

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -75,7 +75,6 @@ def _store(tmp_path, resolver, *lines: str):
 
 
 def test_position_claims_dates_and_qid(tmp_path, resolver: Resolver[Entity]):
-    resolver.load_into_memory()
     store = _store(
         tmp_path,
         resolver,
@@ -95,7 +94,6 @@ def test_position_claims_dates_and_qid(tmp_path, resolver: Resolver[Entity]):
 def test_position_claims_period_fallback_and_skips_unqid(
     tmp_path, resolver: Resolver[Entity]
 ):
-    resolver.load_into_memory()
     store = _store(
         tmp_path,
         resolver,

--- a/tests/test_reconcile_app.py
+++ b/tests/test_reconcile_app.py
@@ -47,7 +47,7 @@ async def test_reconcile_app_navigation(
         '{"id": "os-x", "schema": "Person", '
         '"properties": {"name": ["Vladimir Putin"]}}\n'
     )
-    resolver.begin()
+    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     dataset = Dataset.make({"name": "wikidata"})
     cache = cache_factory(dataset)
@@ -62,7 +62,7 @@ async def test_reconcile_app_navigation(
         )
         app = ReconcileApp[Dataset, Entity]()
         app.reconcile = ReconcileState(
-            resolver, store, dataset, items, commands=enrich
+            db_session, resolver, store, dataset, items, commands=enrich
         )
         async with app.run_test() as pilot:
             state = app.reconcile
@@ -86,7 +86,7 @@ async def test_reconcile_app_negative(
         '{"id": "os-x", "schema": "Person", '
         '"properties": {"name": ["Vladimir Putin"]}}\n'
     )
-    resolver.begin()
+    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     dataset = Dataset.make({"name": "wikidata"})
     cache = cache_factory(dataset)
@@ -101,7 +101,7 @@ async def test_reconcile_app_negative(
         )
         app = ReconcileApp[Dataset, Entity]()
         app.reconcile = ReconcileState(
-            resolver, store, dataset, items, commands=enrich
+            db_session, resolver, store, dataset, items, commands=enrich
         )
         async with app.run_test() as pilot:
             state = app.reconcile
@@ -122,7 +122,7 @@ async def test_reconcile_app_no_candidates(
         '{"id": "os-x", "schema": "Person", '
         '"properties": {"name": ["Nobody At All"]}}\n'
     )
-    resolver.begin()
+    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     dataset = Dataset.make({"name": "wikidata"})
     cache = cache_factory(dataset)
@@ -134,7 +134,7 @@ async def test_reconcile_app_no_candidates(
         )
         app = ReconcileApp[Dataset, Entity]()
         app.reconcile = ReconcileState(
-            resolver, store, dataset, items, commands=enrich
+            db_session, resolver, store, dataset, items, commands=enrich
         )
         async with app.run_test() as pilot:
             state = app.reconcile

--- a/tests/test_reconcile_app.py
+++ b/tests/test_reconcile_app.py
@@ -47,7 +47,6 @@ async def test_reconcile_app_navigation(
         '{"id": "os-x", "schema": "Person", '
         '"properties": {"name": ["Vladimir Putin"]}}\n'
     )
-    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     dataset = Dataset.make({"name": "wikidata"})
     cache = cache_factory(dataset)
@@ -86,7 +85,6 @@ async def test_reconcile_app_negative(
         '{"id": "os-x", "schema": "Person", '
         '"properties": {"name": ["Vladimir Putin"]}}\n'
     )
-    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     dataset = Dataset.make({"name": "wikidata"})
     cache = cache_factory(dataset)
@@ -122,7 +120,6 @@ async def test_reconcile_app_no_candidates(
         '{"id": "os-x", "schema": "Person", '
         '"properties": {"name": ["Nobody At All"]}}\n'
     )
-    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     dataset = Dataset.make({"name": "wikidata"})
     cache = cache_factory(dataset)

--- a/tests/test_reconcile_app.py
+++ b/tests/test_reconcile_app.py
@@ -4,7 +4,6 @@ import requests_mock
 from followthemoney import Dataset
 from followthemoney import StatementEntity as Entity
 
-from nomenklatura.cache import Cache
 from nomenklatura.resolver import Resolver
 from nomenklatura.store import load_entity_file_store
 from nomenklatura.matching import EntityResolveRegression
@@ -40,7 +39,9 @@ def _mock_summary(m):
 
 
 @pytest.mark.asyncio
-async def test_reconcile_app_navigation(tmp_path, resolver: Resolver[Entity]):
+async def test_reconcile_app_navigation(
+    tmp_path, resolver: Resolver[Entity], cache_factory, db_session
+):
     path = tmp_path / "entities.ijson"
     path.write_text(
         '{"id": "os-x", "schema": "Person", '
@@ -49,7 +50,7 @@ async def test_reconcile_app_navigation(tmp_path, resolver: Resolver[Entity]):
     resolver.begin()
     store = load_entity_file_store(path, resolver=resolver)
     dataset = Dataset.make({"name": "wikidata"})
-    cache = Cache.make_default(dataset)
+    cache = cache_factory(dataset)
     with requests_mock.Mocker(real_http=False) as m:
         m.register_uri(
             "GET", WikidataClient.WD_API, json=_dispatch([{"id": "Q7747"}])
@@ -57,7 +58,7 @@ async def test_reconcile_app_navigation(tmp_path, resolver: Resolver[Entity]):
         _mock_summary(m)
         client = WikidataClient(cache)
         items, enrich = prepare_review(
-            resolver, store, client, dataset, EntityResolveRegression
+            resolver, db_session, store, client, dataset, EntityResolveRegression
         )
         app = ReconcileApp[Dataset, Entity]()
         app.reconcile = ReconcileState(
@@ -74,11 +75,12 @@ async def test_reconcile_app_navigation(tmp_path, resolver: Resolver[Entity]):
             assert state.highlight == 1, "down should move to 'none of the above'"
             await pilot.press("up")
             assert state.highlight == 0, "up should move back to the candidate"
-    cache.close()
 
 
 @pytest.mark.asyncio
-async def test_reconcile_app_negative(tmp_path, resolver: Resolver[Entity]):
+async def test_reconcile_app_negative(
+    tmp_path, resolver: Resolver[Entity], cache_factory, db_session
+):
     path = tmp_path / "entities.ijson"
     path.write_text(
         '{"id": "os-x", "schema": "Person", '
@@ -87,7 +89,7 @@ async def test_reconcile_app_negative(tmp_path, resolver: Resolver[Entity]):
     resolver.begin()
     store = load_entity_file_store(path, resolver=resolver)
     dataset = Dataset.make({"name": "wikidata"})
-    cache = Cache.make_default(dataset)
+    cache = cache_factory(dataset)
     with requests_mock.Mocker(real_http=False) as m:
         m.register_uri(
             "GET", WikidataClient.WD_API, json=_dispatch([{"id": "Q7747"}])
@@ -95,7 +97,7 @@ async def test_reconcile_app_negative(tmp_path, resolver: Resolver[Entity]):
         _mock_summary(m)
         client = WikidataClient(cache)
         items, enrich = prepare_review(
-            resolver, store, client, dataset, EntityResolveRegression
+            resolver, db_session, store, client, dataset, EntityResolveRegression
         )
         app = ReconcileApp[Dataset, Entity]()
         app.reconcile = ReconcileState(
@@ -109,11 +111,12 @@ async def test_reconcile_app_negative(tmp_path, resolver: Resolver[Entity]):
             assert state.candidates == []
     # The negative judgement persists so the pair won't be suggested again.
     assert resolver.get_judgement("os-x", "Q7747").value == "negative"
-    cache.close()
 
 
 @pytest.mark.asyncio
-async def test_reconcile_app_no_candidates(tmp_path, resolver: Resolver[Entity]):
+async def test_reconcile_app_no_candidates(
+    tmp_path, resolver: Resolver[Entity], cache_factory, db_session
+):
     path = tmp_path / "entities.ijson"
     path.write_text(
         '{"id": "os-x", "schema": "Person", '
@@ -122,12 +125,12 @@ async def test_reconcile_app_no_candidates(tmp_path, resolver: Resolver[Entity])
     resolver.begin()
     store = load_entity_file_store(path, resolver=resolver)
     dataset = Dataset.make({"name": "wikidata"})
-    cache = Cache.make_default(dataset)
+    cache = cache_factory(dataset)
     with requests_mock.Mocker(real_http=False) as m:
         m.register_uri("GET", WikidataClient.WD_API, json=_dispatch([]))
         client = WikidataClient(cache)
         items, enrich = prepare_review(
-            resolver, store, client, dataset, EntityResolveRegression
+            resolver, db_session, store, client, dataset, EntityResolveRegression
         )
         app = ReconcileApp[Dataset, Entity]()
         app.reconcile = ReconcileState(
@@ -147,4 +150,3 @@ async def test_reconcile_app_no_candidates(tmp_path, resolver: Resolver[Entity])
         from nomenklatura.wikidata.write import CreateItem
 
         assert any(isinstance(c, CreateItem) for c in state.commands)
-    cache.close()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -234,9 +234,13 @@ def test_update_from_db():
     On Postgres this also tests transaction winners.
     """
     # Two sessions over the same db (same cached engine, even in-memory sqlite).
+    # Create + commit the table on the first session before the second attaches:
+    # session.create() runs CREATE TABLE inside the session's transaction, so an
+    # uncommitted create on session1 would block session2's create on Postgres.
     session1 = make_session()
-    session2 = make_session()
     r1 = Resolver(session1, create=True)
+    session1.checkpoint()
+    session2 = make_session()
     r2 = Resolver(session2, create=True)
 
     try:

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -78,7 +78,6 @@ def test_resolver(resolver: Resolver[StatementEntity], db_session):
     # subsequent suggest() updates score
     assert (c1c2 := resolver.get_edge("c1", "c2")) and c1c2.score == 8.0
     ccn = resolver.decide("c1", "c2", Judgement.POSITIVE)
-    # positive decide() replaces the non-canon edge with two towards canonical
     assert resolver.get_edge("c1", "c2") is None
     assert (ccnc2 := resolver.get_edge(ccn, "c2")) and ccnc2.score is None
     assert resolver.get_edge(ccn, "c1") is not None
@@ -225,13 +224,7 @@ def test_linker_non_canonical_cluster():
 
 
 def test_update_from_db():
-    """
-    This tests that one resolver instance can load updates from the db made by
-    another instance.
-
-    On SQLite this is not concurrent - it only tests the update loading.
-    On Postgres this also tests transaction winners.
-    """
+    """Load committed decisions made by another resolver session."""
     session1 = make_session()
     r1 = Resolver(session1, create=True)
     # PostgreSQL locks the uncommitted table creation.
@@ -246,11 +239,7 @@ def test_update_from_db():
         canon_a = r1.decide("a1", "a2", Judgement.POSITIVE, user="r1")
         canon_b = r2.decide("b1", "b2", Judgement.POSITIVE, user="r2")
         assert set(r1.canonicals()) == {canon_a}
-        # decide() refreshes from the db. On Postgres the two sessions hold
-        # separate connections, so r2's refresh can't see r1's uncommitted edge
-        # and each sees only its own decision. In-memory sqlite shares one
-        # connection (SingletonThreadPool), so that isolation doesn't hold —
-        # only assert it where the transaction model provides it.
+        # PostgreSQL sessions cannot see each other's uncommitted decisions.
         if session2.is_postgres:
             assert set(r2.canonicals()) == {canon_b}
         else:
@@ -261,10 +250,8 @@ def test_update_from_db():
 
         r1.load_into_memory()
         r2.load_into_memory()
-        # They see each others' decisions
         assert set(r1.canonicals()) == {canon_a, canon_b}
         assert set(r2.canonicals()) == {canon_a, canon_b}
-        # Validity for delete check
         assert Identifier.get("a2") in r1.connected(canon_a)
         assert Identifier.get("b2") in r2.connected(canon_b)
         r1.remove("b2")
@@ -274,7 +261,6 @@ def test_update_from_db():
 
         r1.load_into_memory()
         r2.load_into_memory()
-        # They see each others' deletes
         assert Identifier.get("a2") not in r1.connected(canon_a)
         assert Identifier.get("b2") not in r2.connected(canon_b)
         session1.checkpoint()
@@ -300,8 +286,7 @@ def test_resolver_store_load(
             assert len(fh.readlines()) == 4
 
         other_table_resolver.load(path)
-        # All four dumped edges land as live judgements (the dump carries no
-        # deleted_at, so the removed a3 edge reloads live).
+        # Dumps do not preserve deletion metadata.
         assert len(list(other_table_resolver.get_judgements())) == 4
 
         edge = other_table_resolver.get_edge("a2", "b2")
@@ -336,9 +321,7 @@ def test_resolver_candidates(resolver: Resolver[StatementEntity], db_session):
 def test_prune_rewrites_noncanonical_target(
     resolver: Resolver[StatementEntity], db_session
 ):
-    # Merging two existing clusters via raw ids leaves a positive edge whose
-    # target is a raw (non-canonical) id. prune's first cleanup job rewrites it
-    # to point at the canonical.
+    # Merge two existing clusters through raw members.
     resolver.decide("a1", "a2", Judgement.POSITIVE)
     resolver.decide("b1", "b2", Judgement.POSITIVE)
     resolver.decide("a1", "b1", Judgement.POSITIVE)
@@ -351,8 +334,6 @@ def test_prune_rewrites_noncanonical_target(
 
     resolver.prune()
 
-    # The raw cross-edge is gone, connectivity is preserved, and no positive
-    # edge with a non-canonical target survives.
     assert resolver.get_edge("a1", "b1") is None
     canon2 = resolver.get_canonical("a1")
     assert all(resolver.get_canonical(n) == canon2 for n in ("a1", "a2", "b1", "b2"))
@@ -365,9 +346,7 @@ def test_prune_rewrites_noncanonical_target(
 def test_prune_simplifies_intermediate_merge(
     resolver: Resolver[StatementEntity], db_session
 ):
-    # A direct canonical<->canonical positive edge is an intermediate merge.
-    # prune's second job (past the cutoff) rewrites the members onto the final
-    # canonical and removes the intermediate edge.
+    # Merge two clusters through their canonical identifiers.
     canon_a = resolver.decide("a1", "a2", Judgement.POSITIVE)
     canon_b = resolver.decide("b1", "b2", Judgement.POSITIVE)
     resolver.decide(canon_a, canon_b, Judgement.POSITIVE)
@@ -376,10 +355,9 @@ def test_prune_simplifies_intermediate_merge(
     canon = resolver.get_canonical("a1")
     assert all(resolver.get_canonical(n) == canon for n in ("a2", "b1", "b2"))
 
-    # Negative cleanup window puts the cutoff in the future so fresh edges qualify.
+    # Put the cleanup cutoff in the future so fresh edges qualify.
     resolver.prune(cleanup_after=timedelta(days=-3650))
 
-    # The intermediate edge is gone and connectivity is preserved.
     assert resolver.get_edge(canon_a, canon_b) is None
     canon2 = resolver.get_canonical("a1")
     assert all(resolver.get_canonical(n) == canon2 for n in ("a1", "a2", "b1", "b2"))
@@ -439,6 +417,5 @@ def test_table_name(
     assert other_table_resolver.get_canonical("a1") == a_canon
     assert set(other_table_resolver.canonicals()) == {a_canon}
     assert other_table_resolver.get_edge("a1", a_canon) is not None
-    # Only this resolver's own two edges live in the other table.
     assert len(list(other_table_resolver.get_judgements())) == 2
     assert "another_table" in repr(other_table_resolver)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -327,6 +327,30 @@ def test_resolver_candidates(resolver: Resolver[StatementEntity], db_session):
     db_session.checkpoint()
 
 
+def test_rename_qid_node(resolver: Resolver[StatementEntity], db_session):
+    resolver.decide("os-1", "Q123", Judgement.POSITIVE)
+    resolver.decide("os-2", "Q456", Judgement.POSITIVE)
+    resolver.decide("os-3", "Q123", Judgement.NEGATIVE)
+    resolver.suggest("os-4", "Q123", 0.75, user="test")
+
+    assert resolver.get_canonical("os-1") == "Q123"
+    assert resolver.get_judgement("os-3", "Q123") == Judgement.NEGATIVE
+
+    assert resolver.rename_node("Q123", "Q789") == 3
+
+    assert resolver.get_canonical("os-1") == "Q789"
+    assert resolver.get_judgement("os-1", "Q789") == Judgement.POSITIVE
+    assert resolver.get_judgement("os-3", "Q789") == Judgement.NEGATIVE
+    assert resolver.get_judgement("os-3", "Q123") == Judgement.NO_JUDGEMENT
+    assert ("Q789", "os-4", 0.75) in list(resolver.get_candidates())
+    assert resolver.get_edge("os-1", "Q123") is None
+    assert resolver.get_edge("os-3", "Q123") is None
+    assert resolver.get_edge("os-4", "Q123") is None
+
+    assert resolver.get_canonical("os-2") == "Q456"
+    db_session.checkpoint()
+
+
 def test_prune_rewrites_noncanonical_target(
     resolver: Resolver[StatementEntity], db_session
 ):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -180,6 +180,8 @@ def test_linker(resolver: Resolver[StatementEntity], db_session):
     assert linker.get_canonical("c2") == "c2"
     assert linker.get_canonical("x1") == "x1"
     assert linker.get_canonical("a3") == "a3"
+    assert linker.connected_ids("a1") == linker._mapping["a1"]
+    assert linker.connected_ids("unknown") == ("unknown",)
 
     # get_referents with canonicals=False excludes NK- and QID entries
     refs_no_canon = linker.get_referents("Q123", canonicals=False)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -4,6 +4,7 @@ from typing import Dict, Tuple
 from followthemoney import Statement, StatementEntity
 
 from nomenklatura import settings
+from nomenklatura.db import make_session
 from nomenklatura.judgement import Judgement
 from nomenklatura.resolver import Identifier
 from nomenklatura.resolver.edge import Edge
@@ -30,8 +31,7 @@ def test_qid_identifier():
     assert max(nk, regular) == nk
 
 
-def test_resolver(resolver: Resolver[StatementEntity]):
-    resolver.begin()
+def test_resolver(resolver: Resolver[StatementEntity], db_session):
     a_canon = resolver.decide("a1", "a2", Judgement.POSITIVE)
     assert a_canon.canonical, a_canon
     assert Identifier.get("a2") in resolver.connected(Identifier.get("a1"))
@@ -103,11 +103,10 @@ def test_resolver(resolver: Resolver[StatementEntity]):
     assert resolver.get_judgement("b1", "b2") == Judgement.POSITIVE
 
     # Can we actually commit after all these operations?
-    resolver.commit()
+    db_session.checkpoint()
 
 
-def test_cluster_to_cluster(resolver: Resolver[StatementEntity]):
-    resolver.begin()
+def test_cluster_to_cluster(resolver: Resolver[StatementEntity], db_session):
     a_canon = resolver.decide("a1", "a2", Judgement.POSITIVE)
     b_canon = resolver.decide("b1", "b2", Judgement.POSITIVE)
     resolver.decide(a_canon, b_canon, Judgement.UNSURE)
@@ -153,18 +152,17 @@ def test_cluster_to_cluster(resolver: Resolver[StatementEntity]):
     assert "a3" not in connected
 
     # Can we actually commit after all these operations?
-    resolver.commit()
+    db_session.checkpoint()
 
 
-def test_linker(resolver: Resolver[StatementEntity]):
-    resolver.begin()
+def test_linker(resolver: Resolver[StatementEntity], db_session):
     canon_a = resolver.decide("a1", "a2", Judgement.POSITIVE)
     canon_a = resolver.decide(canon_a, "a3", Judgement.POSITIVE)
     resolver.remove("a3")
     canon_b = resolver.decide("b1", "b2", Judgement.POSITIVE)
     resolver.decide("a1", "Q123", Judgement.POSITIVE)
     resolver.decide("a2", "c2", Judgement.NEGATIVE)
-    resolver.commit()
+    db_session.checkpoint()
     linker = resolver.get_linker()
 
     assert len(linker.connected(canon_a)) == 4
@@ -235,25 +233,26 @@ def test_update_from_db():
     On SQLite this is not concurrent - it only tests the update loading.
     On Postgres this also tests transaction winners.
     """
-    r1 = Resolver.make_default()
-    # we don't get_engine.cache_clear() because we want the same db,
-    # even when using in-memory sqlite.
-    r2 = Resolver.make_default()
+    # Two sessions over the same db (same cached engine, even in-memory sqlite).
+    session1 = make_session()
+    session2 = make_session()
+    r1 = Resolver(session1, create=True)
+    r2 = Resolver(session2, create=True)
 
     try:
-        r1.begin()
-        r2.begin()
+        r1.load_into_memory()
+        r2.load_into_memory()
         assert set(r1.canonicals()) == set()
         canon_a = r1.decide("a1", "a2", Judgement.POSITIVE, user="r1")
         canon_b = r2.decide("b1", "b2", Judgement.POSITIVE, user="r2")
         assert set(r1.canonicals()) == {canon_a}
         assert set(r2.canonicals()) == {canon_b}
         r1.suggest(canon_a, "a3", 1.0, "test user")
-        r1.commit()
-        r2.commit()
+        session1.checkpoint()
+        session2.checkpoint()
 
-        r1.begin()
-        r2.begin()
+        r1.load_into_memory()
+        r2.load_into_memory()
         # They see each others' decisions
         assert set(r1.canonicals()) == {canon_a, canon_b}
         assert set(r2.canonicals()) == {canon_a, canon_b}
@@ -262,26 +261,19 @@ def test_update_from_db():
         assert Identifier.get("b2") in r2.connected(canon_b)
         r1.remove("b2")
         r2.remove("a2")
-        r1.commit()
-        r2.commit()
+        session1.checkpoint()
+        session2.checkpoint()
 
-        r1.begin()
-        r2.begin()
+        r1.load_into_memory()
+        r2.load_into_memory()
         # They see each others' deletes
         assert Identifier.get("a2") not in r1.connected(canon_a)
         assert Identifier.get("b2") not in r2.connected(canon_b)
-        r1.commit()
-        r2.commit()
-
-        # r1.begin()
-        # from pprint import pprint
-        # from sqlalchemy import text
-        # pprint(r1._get_connection().execute(text("SELECT * FROM resolver")).fetchall())
-        # assert False
+        session1.checkpoint()
+        session2.checkpoint()
     finally:
-        r1.rollback()
-        r2.rollback()
-        r1._table.drop(r1._engine)
+        session1.close()
+        session2.close()
 
 
 def test_resolver_store_load(
@@ -289,7 +281,6 @@ def test_resolver_store_load(
 ):
     with NamedTemporaryFile("w") as fh:
         path = Path(fh.name)
-        resolver.begin()
         canon_a = resolver.decide("a1", "a2", Judgement.POSITIVE)
         resolver.decide(canon_a, "a3", Judgement.POSITIVE)
         resolver.remove("a3")
@@ -300,7 +291,6 @@ def test_resolver_store_load(
         with open(path, "r") as fh:
             assert len(fh.readlines()) == 4
 
-        other_table_resolver.begin()
         other_table_resolver.load(path)
         assert len(other_table_resolver.edges) == len(resolver.edges)
 
@@ -313,8 +303,7 @@ def test_resolver_store_load(
         assert edge is None, edge
 
 
-def test_resolver_candidates(resolver: Resolver[StatementEntity]):
-    resolver.begin()
+def test_resolver_candidates(resolver: Resolver[StatementEntity], db_session):
     candidates = list(resolver.get_candidates())
     assert len(candidates) == 0, candidates
 
@@ -331,11 +320,10 @@ def test_resolver_candidates(resolver: Resolver[StatementEntity]):
     resolver.prune()
     candidates = list(resolver.get_candidates())
     assert len(candidates) == 0, candidates
-    resolver.commit()
+    db_session.checkpoint()
 
 
 def test_get_judgements(resolver: Resolver[StatementEntity]):
-    resolver.begin()
     canon = resolver.decide("a1", "a2", Judgement.POSITIVE)
     resolver.decide(canon, "a3", Judgement.POSITIVE)
     resolver.decide(canon, "a4", Judgement.POSITIVE)
@@ -357,7 +345,6 @@ def test_get_judgements(resolver: Resolver[StatementEntity]):
 def test_resolver_statements(
     resolver: Resolver[StatementEntity], other_table_resolver: Resolver[StatementEntity]
 ):
-    resolver.begin()
     canon = resolver.decide("a1", "a2", Judgement.POSITIVE)
     resolver.decide("a2", "b2", Judgement.NEGATIVE)
 
@@ -369,22 +356,21 @@ def test_resolver_statements(
     assert stmt.value == "b2"
 
     # A resolver that doesn't know about the entity doesn't alter stmt.
-    other_table_resolver.begin()
     stmt = other_table_resolver.apply_statement(stmt)
     assert stmt.canonical_id == "a1"
     assert stmt.value == "b2"
 
 
 def test_table_name(
-    resolver: Resolver[StatementEntity], other_table_resolver: Resolver[StatementEntity]
+    resolver: Resolver[StatementEntity],
+    other_table_resolver: Resolver[StatementEntity],
+    db_session,
 ):
     """Make fairly sure that we're hitting the correct table"""
-    resolver.begin()
     resolver.decide("b1", "b2", Judgement.POSITIVE)  # No a1
     resolver.decide("c1", "c2", Judgement.POSITIVE)  # 4 edges
-    resolver.commit()
+    db_session.checkpoint()
 
-    other_table_resolver.begin()
     a_canon = other_table_resolver.decide("a1", "a2", Judgement.POSITIVE)
     assert other_table_resolver.get_judgement("a1", "a2") == Judgement.POSITIVE
     assert other_table_resolver.get_canonical("a1") == a_canon

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -36,7 +36,8 @@ def test_resolver(resolver: Resolver[StatementEntity], db_session):
     a_canon = resolver.decide("a1", "a2", Judgement.POSITIVE)
     assert a_canon.canonical, a_canon
     assert Identifier.get("a2") in resolver.connected(Identifier.get("a1"))
-    assert set(n.id for n in resolver.nodes) == {"a1", "a2", a_canon.id}
+    cluster = resolver.connected(Identifier.get("a1"))
+    assert set(n.id for n in cluster) == {"a1", "a2", a_canon.id}
 
     assert resolver.get_judgement("a1", "a2") == Judgement.POSITIVE
     resolver.decide("b1", "b2", Judgement.POSITIVE)
@@ -74,18 +75,15 @@ def test_resolver(resolver: Resolver[StatementEntity], db_session):
     resolver.suggest("c1", "c2", 7.0)
     assert (c1c2 := resolver.get_edge("c1", "c2")) and c1c2.score == 7.0
     resolver.suggest("c1", "c2", 8.0)
-    edge_count = len(resolver.edges)
     # subsequent suggest() updates score
     assert (c1c2 := resolver.get_edge("c1", "c2")) and c1c2.score == 8.0
-    assert c1c2 in resolver.edges, resolver.edges
     ccn = resolver.decide("c1", "c2", Judgement.POSITIVE)
+    # positive decide() replaces the non-canon edge with two towards canonical
     assert resolver.get_edge("c1", "c2") is None
     assert (ccnc2 := resolver.get_edge(ccn, "c2")) and ccnc2.score is None
-    # positive decide() replaces non-canon edge with two towards canonical
-
-    assert ccnc2.key in resolver.edges, resolver.edges
-    assert c1c2.key not in resolver.edges, resolver.edges
-    assert len(resolver.edges) == edge_count + 1
+    assert resolver.get_edge(ccn, "c1") is not None
+    assert resolver.get_canonical("c1") == ccn
+    assert resolver.get_canonical("c2") == ccn
 
     assert "a1" in resolver.get_referents(a_canon.id)
     assert "a1" in resolver.get_referents(a_canon.id, canonicals=False)
@@ -248,7 +246,15 @@ def test_update_from_db():
         canon_a = r1.decide("a1", "a2", Judgement.POSITIVE, user="r1")
         canon_b = r2.decide("b1", "b2", Judgement.POSITIVE, user="r2")
         assert set(r1.canonicals()) == {canon_a}
-        assert set(r2.canonicals()) == {canon_b}
+        # decide() refreshes from the db. On Postgres the two sessions hold
+        # separate connections, so r2's refresh can't see r1's uncommitted edge
+        # and each sees only its own decision. In-memory sqlite shares one
+        # connection (SingletonThreadPool), so that isolation doesn't hold —
+        # only assert it where the transaction model provides it.
+        if session2.is_postgres:
+            assert set(r2.canonicals()) == {canon_b}
+        else:
+            assert canon_b in set(r2.canonicals())
         r1.suggest(canon_a, "a3", 1.0, "test user")
         session1.checkpoint()
         session2.checkpoint()
@@ -294,7 +300,9 @@ def test_resolver_store_load(
             assert len(fh.readlines()) == 4
 
         other_table_resolver.load(path)
-        assert len(other_table_resolver.edges) == len(resolver.edges)
+        # All four dumped edges land as live judgements (the dump carries no
+        # deleted_at, so the removed a3 edge reloads live).
+        assert len(list(other_table_resolver.get_judgements())) == 4
 
         edge = other_table_resolver.get_edge("a2", "b2")
         assert edge is not None, edge
@@ -431,5 +439,6 @@ def test_table_name(
     assert other_table_resolver.get_canonical("a1") == a_canon
     assert set(other_table_resolver.canonicals()) == {a_canon}
     assert other_table_resolver.get_edge("a1", a_canon) is not None
-    assert len(other_table_resolver.edges) == 2
+    # Only this resolver's own two edges live in the other table.
+    assert len(list(other_table_resolver.get_judgements())) == 2
     assert "another_table" in repr(other_table_resolver)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Dict, Tuple
@@ -321,6 +322,59 @@ def test_resolver_candidates(resolver: Resolver[StatementEntity], db_session):
     resolver.prune()
     candidates = list(resolver.get_candidates())
     assert len(candidates) == 0, candidates
+    db_session.checkpoint()
+
+
+def test_prune_rewrites_noncanonical_target(
+    resolver: Resolver[StatementEntity], db_session
+):
+    # Merging two existing clusters via raw ids leaves a positive edge whose
+    # target is a raw (non-canonical) id. prune's first cleanup job rewrites it
+    # to point at the canonical.
+    resolver.decide("a1", "a2", Judgement.POSITIVE)
+    resolver.decide("b1", "b2", Judgement.POSITIVE)
+    resolver.decide("a1", "b1", Judgement.POSITIVE)
+
+    cross = resolver.get_edge("a1", "b1")
+    assert cross is not None and cross.judgement == Judgement.POSITIVE, cross
+    assert not (cross.target.canonical and cross.source.canonical), cross
+    canon = resolver.get_canonical("a1")
+    assert all(resolver.get_canonical(n) == canon for n in ("a2", "b1", "b2"))
+
+    resolver.prune()
+
+    # The raw cross-edge is gone, connectivity is preserved, and no positive
+    # edge with a non-canonical target survives.
+    assert resolver.get_edge("a1", "b1") is None
+    canon2 = resolver.get_canonical("a1")
+    assert all(resolver.get_canonical(n) == canon2 for n in ("a1", "a2", "b1", "b2"))
+    for edge in resolver.get_judgements():
+        if edge.judgement == Judgement.POSITIVE:
+            assert edge.target.canonical, edge
+    db_session.checkpoint()
+
+
+def test_prune_simplifies_intermediate_merge(
+    resolver: Resolver[StatementEntity], db_session
+):
+    # A direct canonical<->canonical positive edge is an intermediate merge.
+    # prune's second job (past the cutoff) rewrites the members onto the final
+    # canonical and removes the intermediate edge.
+    canon_a = resolver.decide("a1", "a2", Judgement.POSITIVE)
+    canon_b = resolver.decide("b1", "b2", Judgement.POSITIVE)
+    resolver.decide(canon_a, canon_b, Judgement.POSITIVE)
+
+    assert resolver.get_edge(canon_a, canon_b) is not None
+    canon = resolver.get_canonical("a1")
+    assert all(resolver.get_canonical(n) == canon for n in ("a2", "b1", "b2"))
+
+    # Negative cleanup window puts the cutoff in the future so fresh edges qualify.
+    resolver.prune(cleanup_after=timedelta(days=-3650))
+
+    # The intermediate edge is gone and connectivity is preserved.
+    assert resolver.get_edge(canon_a, canon_b) is None
+    canon2 = resolver.get_canonical("a1")
+    assert all(resolver.get_canonical(n) == canon2 for n in ("a1", "a2", "b1", "b2"))
     db_session.checkpoint()
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -233,12 +233,9 @@ def test_update_from_db():
     On SQLite this is not concurrent - it only tests the update loading.
     On Postgres this also tests transaction winners.
     """
-    # Two sessions over the same db (same cached engine, even in-memory sqlite).
-    # Create + commit the table on the first session before the second attaches:
-    # session.create() runs CREATE TABLE inside the session's transaction, so an
-    # uncommitted create on session1 would block session2's create on Postgres.
     session1 = make_session()
     r1 = Resolver(session1, create=True)
+    # PostgreSQL locks the uncommitted table creation.
     session1.checkpoint()
     session2 = make_session()
     r2 = Resolver(session2, create=True)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -77,6 +77,13 @@ def test_resolver(resolver: Resolver[StatementEntity], db_session):
     resolver.suggest("c1", "c2", 8.0)
     # subsequent suggest() updates score
     assert (c1c2 := resolver.get_edge("c1", "c2")) and c1c2.score == 8.0
+    resolver.suggest("c1", "c2", 0.0)
+    assert (c1c2 := resolver.get_edge("c1", "c2")) and c1c2.score == 0.0
+    resolver.decide("guard1", "guard2", Judgement.NEGATIVE)
+    resolver.suggest("guard1", "guard2", 9.0)
+    assert (guard := resolver.get_edge("guard1", "guard2"))
+    assert guard.judgement == Judgement.NEGATIVE
+    assert guard.score is None
     ccn = resolver.decide("c1", "c2", Judgement.POSITIVE)
     assert resolver.get_edge("c1", "c2") is None
     assert (ccnc2 := resolver.get_edge(ccn, "c2")) and ccnc2.score is None

--- a/tests/test_wikidata.py
+++ b/tests/test_wikidata.py
@@ -236,7 +236,6 @@ def test_reconcile_auto(tmp_path, resolver: Resolver[Entity], cache_factory, db_
         '{"id": "os-nobody", "schema": "Person", '
         '"properties": {"name": ["Jane Q Nobody"]}}\n'
     )
-    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     dataset = Dataset.make({"name": "wikidata", "title": "Wikidata"})
 
@@ -304,7 +303,6 @@ def test_reconcile_wikidata_id(tmp_path, resolver: Resolver[Entity], cache_facto
         '{"id": "os-putin", "schema": "Person", "properties": '
         '{"name": ["Vladimir Putin"], "wikidataId": ["Q7747"]}}\n'
     )
-    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     dataset = Dataset.make({"name": "wikidata", "title": "Wikidata"})
     cache = cache_factory(dataset)
@@ -350,7 +348,6 @@ def test_reconcile_state_confirm(tmp_path, resolver: Resolver[Entity], cache_fac
         '{"id": "os-putin", "schema": "Person", "properties": '
         '{"name": ["Vladimir Putin"], "birthDate": ["1952-10-07"]}}\n'
     )
-    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     cache = cache_factory(Dataset.make({"name": "wikidata"}))
     with requests_mock.Mocker(real_http=False) as m:
@@ -375,7 +372,6 @@ def test_reconcile_state_create(tmp_path, resolver: Resolver[Entity], cache_fact
         '{"id": "os-nobody", "schema": "Person", '
         '"properties": {"name": ["Jane Q Nobody"]}}\n'
     )
-    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     cache = cache_factory(Dataset.make({"name": "wikidata"}))
     with requests_mock.Mocker(real_http=False) as m:
@@ -397,7 +393,6 @@ def test_reconcile_state_skip(tmp_path, resolver: Resolver[Entity], cache_factor
         '{"id": "os-nobody", "schema": "Person", '
         '"properties": {"name": ["Jane Q Nobody"]}}\n'
     )
-    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     cache = cache_factory(Dataset.make({"name": "wikidata"}))
     with requests_mock.Mocker(real_http=False) as m:
@@ -415,7 +410,6 @@ def test_reconcile_state_linked_skipped(tmp_path, resolver: Resolver[Entity], ca
         '{"id": "os-putin", "schema": "Person", "properties": '
         '{"name": ["Vladimir Putin"], "wikidataId": ["Q7747"]}}\n'
     )
-    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     cache = cache_factory(Dataset.make({"name": "wikidata"}))
     with requests_mock.Mocker(real_http=False) as m:

--- a/tests/test_wikidata.py
+++ b/tests/test_wikidata.py
@@ -236,7 +236,7 @@ def test_reconcile_auto(tmp_path, resolver: Resolver[Entity], cache_factory, db_
         '{"id": "os-nobody", "schema": "Person", '
         '"properties": {"name": ["Jane Q Nobody"]}}\n'
     )
-    resolver.begin()
+    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     dataset = Dataset.make({"name": "wikidata", "title": "Wikidata"})
 
@@ -304,7 +304,7 @@ def test_reconcile_wikidata_id(tmp_path, resolver: Resolver[Entity], cache_facto
         '{"id": "os-putin", "schema": "Person", "properties": '
         '{"name": ["Vladimir Putin"], "wikidataId": ["Q7747"]}}\n'
     )
-    resolver.begin()
+    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     dataset = Dataset.make({"name": "wikidata", "title": "Wikidata"})
     cache = cache_factory(dataset)
@@ -328,7 +328,7 @@ def _reconcile_state(resolver, session, store, cache):
     items, commands = prepare_review(
         resolver, session, store, client, dataset, EntityResolveRegression
     )
-    return ReconcileState(resolver, store, dataset, items, commands=commands)
+    return ReconcileState(session, resolver, store, dataset, items, commands=commands)
 
 
 def test_create_preview():
@@ -350,7 +350,7 @@ def test_reconcile_state_confirm(tmp_path, resolver: Resolver[Entity], cache_fac
         '{"id": "os-putin", "schema": "Person", "properties": '
         '{"name": ["Vladimir Putin"], "birthDate": ["1952-10-07"]}}\n'
     )
-    resolver.begin()
+    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     cache = cache_factory(Dataset.make({"name": "wikidata"}))
     with requests_mock.Mocker(real_http=False) as m:
@@ -375,7 +375,7 @@ def test_reconcile_state_create(tmp_path, resolver: Resolver[Entity], cache_fact
         '{"id": "os-nobody", "schema": "Person", '
         '"properties": {"name": ["Jane Q Nobody"]}}\n'
     )
-    resolver.begin()
+    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     cache = cache_factory(Dataset.make({"name": "wikidata"}))
     with requests_mock.Mocker(real_http=False) as m:
@@ -397,7 +397,7 @@ def test_reconcile_state_skip(tmp_path, resolver: Resolver[Entity], cache_factor
         '{"id": "os-nobody", "schema": "Person", '
         '"properties": {"name": ["Jane Q Nobody"]}}\n'
     )
-    resolver.begin()
+    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     cache = cache_factory(Dataset.make({"name": "wikidata"}))
     with requests_mock.Mocker(real_http=False) as m:
@@ -415,7 +415,7 @@ def test_reconcile_state_linked_skipped(tmp_path, resolver: Resolver[Entity], ca
         '{"id": "os-putin", "schema": "Person", "properties": '
         '{"name": ["Vladimir Putin"], "wikidataId": ["Q7747"]}}\n'
     )
-    resolver.begin()
+    resolver.load_into_memory()
     store = load_entity_file_store(path, resolver=resolver)
     cache = cache_factory(Dataset.make({"name": "wikidata"}))
     with requests_mock.Mocker(real_http=False) as m:

--- a/tests/test_wikidata.py
+++ b/tests/test_wikidata.py
@@ -228,7 +228,7 @@ def test_candidate_proxy(test_cache: Cache):
         assert "ru" in proxy.get("citizenship")
 
 
-def test_reconcile_auto(tmp_path, resolver: Resolver[Entity]):
+def test_reconcile_auto(tmp_path, resolver: Resolver[Entity], cache_factory, db_session):
     path = tmp_path / "entities.ijson"
     path.write_text(
         '{"id": "os-putin", "schema": "Person", '
@@ -240,7 +240,7 @@ def test_reconcile_auto(tmp_path, resolver: Resolver[Entity]):
     store = load_entity_file_store(path, resolver=resolver)
     dataset = Dataset.make({"name": "wikidata", "title": "Wikidata"})
 
-    cache = Cache.make_default(dataset)
+    cache = cache_factory(dataset)
     with requests_mock.Mocker(real_http=False) as m:
         # Both persons' searches return Putin's QID; only the real Putin scores.
         m.register_uri(
@@ -250,12 +250,12 @@ def test_reconcile_auto(tmp_path, resolver: Resolver[Entity]):
         )
         client = WikidataClient(cache)
         commands = reconcile(
-            resolver, store, client, dataset, EntityResolveRegression,
+            resolver, db_session, store, client, dataset, EntityResolveRegression,
             threshold=0.5, create=True,
         )
         # Without create=True the unmatched person yields no create commands.
         no_create = reconcile(
-            resolver, store, client, dataset, EntityResolveRegression,
+            resolver, db_session, store, client, dataset, EntityResolveRegression,
             threshold=0.5, create=False,
         )
 
@@ -268,8 +268,6 @@ def test_reconcile_auto(tmp_path, resolver: Resolver[Entity]):
 
     assert any(isinstance(c, CreateItem) for c in commands)
     assert not any(isinstance(c, CreateItem) for c in no_create)
-    cache.close()
-
 
 def test_entity_qid():
     from nomenklatura.wikidata.util import entity_qid
@@ -298,7 +296,7 @@ def test_entity_qid():
     assert entity_qid(none) is None
 
 
-def test_reconcile_wikidata_id(tmp_path, resolver: Resolver[Entity]):
+def test_reconcile_wikidata_id(tmp_path, resolver: Resolver[Entity], cache_factory, db_session):
     # A person already linked via the wikidataId property is enriched, not
     # re-searched or proposed for creation.
     path = tmp_path / "entities.ijson"
@@ -309,28 +307,26 @@ def test_reconcile_wikidata_id(tmp_path, resolver: Resolver[Entity]):
     resolver.begin()
     store = load_entity_file_store(path, resolver=resolver)
     dataset = Dataset.make({"name": "wikidata", "title": "Wikidata"})
-    cache = Cache.make_default(dataset)
+    cache = cache_factory(dataset)
     with requests_mock.Mocker(real_http=False) as m:
         m.register_uri("GET", WikidataClient.WD_API, json=wd_read_response)
         client = WikidataClient(cache)
         commands = reconcile(
-            resolver, store, client, dataset, EntityResolveRegression, threshold=0.5
+            resolver, db_session, store, client, dataset, EntityResolveRegression, threshold=0.5
         )
     # No CREATE for a linked entity; enrichment was attempted against Q7747.
     from nomenklatura.wikidata.write import CreateItem
 
     assert not any(isinstance(c, CreateItem) for c in commands)
-    cache.close()
 
-
-def _reconcile_state(resolver, store, cache):
+def _reconcile_state(resolver, session, store, cache):
     from nomenklatura.tui.reconcile import ReconcileState
     from nomenklatura.wikidata.reconcile import prepare_review
 
     dataset = Dataset.make({"name": "wikidata", "title": "Wikidata"})
     client = WikidataClient(cache)
     items, commands = prepare_review(
-        resolver, store, client, dataset, EntityResolveRegression
+        resolver, session, store, client, dataset, EntityResolveRegression
     )
     return ReconcileState(resolver, store, dataset, items, commands=commands)
 
@@ -348,7 +344,7 @@ def test_create_preview():
     assert preview.get("birthDate") == []
 
 
-def test_reconcile_state_confirm(tmp_path, resolver: Resolver[Entity]):
+def test_reconcile_state_confirm(tmp_path, resolver: Resolver[Entity], cache_factory, db_session):
     path = tmp_path / "entities.ijson"
     path.write_text(
         '{"id": "os-putin", "schema": "Person", "properties": '
@@ -356,7 +352,7 @@ def test_reconcile_state_confirm(tmp_path, resolver: Resolver[Entity]):
     )
     resolver.begin()
     store = load_entity_file_store(path, resolver=resolver)
-    cache = Cache.make_default(Dataset.make({"name": "wikidata"}))
+    cache = cache_factory(Dataset.make({"name": "wikidata"}))
     with requests_mock.Mocker(real_http=False) as m:
         m.register_uri("GET", WikidataClient.WD_API, json=_wd_dispatch([{"id": "Q7747"}]))
         m.register_uri(
@@ -364,7 +360,7 @@ def test_reconcile_state_confirm(tmp_path, resolver: Resolver[Entity]):
             re.compile(r"\.wikipedia\.org/api/rest_v1/page/summary/"),
             json={"extract": "Vladimir Putin is a politician."},
         )
-        state = _reconcile_state(resolver, store, cache)
+        state = _reconcile_state(resolver, db_session, store, cache)
         assert state.start() is True
         assert state.person is not None
         assert state.candidates[0][0].id == "Q7747"
@@ -372,10 +368,8 @@ def test_reconcile_state_confirm(tmp_path, resolver: Resolver[Entity]):
         state.highlight = 0
         state.confirm()
     assert resolver.get_canonical("os-putin") == "Q7747"
-    cache.close()
 
-
-def test_reconcile_state_create(tmp_path, resolver: Resolver[Entity]):
+def test_reconcile_state_create(tmp_path, resolver: Resolver[Entity], cache_factory, db_session):
     path = tmp_path / "entities.ijson"
     path.write_text(
         '{"id": "os-nobody", "schema": "Person", '
@@ -383,11 +377,11 @@ def test_reconcile_state_create(tmp_path, resolver: Resolver[Entity]):
     )
     resolver.begin()
     store = load_entity_file_store(path, resolver=resolver)
-    cache = Cache.make_default(Dataset.make({"name": "wikidata"}))
+    cache = cache_factory(Dataset.make({"name": "wikidata"}))
     with requests_mock.Mocker(real_http=False) as m:
         # No search hits: the only row is "None of the above".
         m.register_uri("GET", WikidataClient.WD_API, json=_wd_dispatch([]))
-        state = _reconcile_state(resolver, store, cache)
+        state = _reconcile_state(resolver, db_session, store, cache)
         assert state.start() is True
         assert state.candidates == []
         assert state.at_create is True
@@ -396,10 +390,8 @@ def test_reconcile_state_create(tmp_path, resolver: Resolver[Entity]):
 
     assert any(isinstance(c, CreateItem) for c in state.commands)
     assert resolver.get_canonical("os-nobody") == "os-nobody"
-    cache.close()
 
-
-def test_reconcile_state_skip(tmp_path, resolver: Resolver[Entity]):
+def test_reconcile_state_skip(tmp_path, resolver: Resolver[Entity], cache_factory, db_session):
     path = tmp_path / "entities.ijson"
     path.write_text(
         '{"id": "os-nobody", "schema": "Person", '
@@ -407,18 +399,16 @@ def test_reconcile_state_skip(tmp_path, resolver: Resolver[Entity]):
     )
     resolver.begin()
     store = load_entity_file_store(path, resolver=resolver)
-    cache = Cache.make_default(Dataset.make({"name": "wikidata"}))
+    cache = cache_factory(Dataset.make({"name": "wikidata"}))
     with requests_mock.Mocker(real_http=False) as m:
         m.register_uri("GET", WikidataClient.WD_API, json=_wd_dispatch([]))
-        state = _reconcile_state(resolver, store, cache)
+        state = _reconcile_state(resolver, db_session, store, cache)
         assert state.start() is True
         state.skip()
     assert state.commands == []
     assert resolver.get_canonical("os-nobody") == "os-nobody"
-    cache.close()
 
-
-def test_reconcile_state_linked_skipped(tmp_path, resolver: Resolver[Entity]):
+def test_reconcile_state_linked_skipped(tmp_path, resolver: Resolver[Entity], cache_factory, db_session):
     # A person already linked via wikidataId is enriched silently, gets no screen.
     path = tmp_path / "entities.ijson"
     path.write_text(
@@ -427,15 +417,13 @@ def test_reconcile_state_linked_skipped(tmp_path, resolver: Resolver[Entity]):
     )
     resolver.begin()
     store = load_entity_file_store(path, resolver=resolver)
-    cache = Cache.make_default(Dataset.make({"name": "wikidata"}))
+    cache = cache_factory(Dataset.make({"name": "wikidata"}))
     with requests_mock.Mocker(real_http=False) as m:
         m.register_uri("GET", WikidataClient.WD_API, json=wd_read_response)
-        state = _reconcile_state(resolver, store, cache)
+        state = _reconcile_state(resolver, db_session, store, cache)
         # No reviewable person; the linked one was enriched during load.
         assert state.start() is False
         assert state.person is None
-    cache.close()
-
 
 def test_model(test_cache: Cache):
     with requests_mock.Mocker(real_http=False) as m:

--- a/tests/test_wikipedia.py
+++ b/tests/test_wikipedia.py
@@ -3,7 +3,6 @@ import requests_mock
 from followthemoney import Dataset
 from followthemoney import StatementEntity as Entity
 
-from nomenklatura.cache import Cache
 from nomenklatura.wikidata.model import Item
 from nomenklatura.wikidata.util import make_session
 from nomenklatura.wikidata.wikipedia import (
@@ -45,19 +44,18 @@ def test_preferred_langs_multilingual_country() -> None:
     assert langs[:4] == ["deu", "fra", "ita", "roh"]
 
 
-def test_fetch_summary_negative_cache() -> None:
-    cache = Cache.make_default(Dataset.make({"name": "wikidata"}))
+def test_fetch_summary_negative_cache(cache_factory) -> None:
+    cache = cache_factory(Dataset.make({"name": "wikidata"}))
     session = make_session()
     with requests_mock.Mocker(real_http=False) as m:
         m.register_uri("GET", SUMMARY_URL, status_code=404)
         assert fetch_summary(cache, session, "en", "Nobody") is None
     # A second call is served from the empty-string sentinel, no HTTP needed.
     assert fetch_summary(cache, session, "en", "Nobody") is None
-    cache.close()
 
 
-def test_item_summaries_preferred_only_and_capped() -> None:
-    cache = Cache.make_default(Dataset.make({"name": "wikidata"}))
+def test_item_summaries_preferred_only_and_capped(cache_factory) -> None:
+    cache = cache_factory(Dataset.make({"name": "wikidata"}))
     session = make_session()
     # enwiki/dewiki are preferred; the made-up 'xxwiki' is not and must be skipped.
     item = _item("enwiki", "dewiki", "xxwiki")
@@ -72,4 +70,3 @@ def test_item_summaries_preferred_only_and_capped() -> None:
         # No fill from the non-preferred language even with budget to spare.
         many = item_wikipedia_summaries(cache, session, item, ["deu", "eng"])
         assert {s.lang for s in many} == {"deu", "eng"}
-    cache.close()

--- a/tests/test_xref.py
+++ b/tests/test_xref.py
@@ -7,9 +7,12 @@ from nomenklatura.xref import xref
 
 
 def test_xref_candidates(
-    index_path: Path, resolver: Resolver[StatementEntity], dstore: SimpleMemoryStore
+    index_path: Path,
+    resolver: Resolver[StatementEntity],
+    dstore: SimpleMemoryStore,
+    db_session,
 ):
-    xref(resolver, dstore, index_path)
+    xref(resolver, db_session, dstore, index_path)
     view = dstore.default_view(external=True)
     candidates = list(resolver.get_candidates(limit=20))
     assert len(candidates) == 20


### PR DESCRIPTION
## Why

A caching utility owned the process's database session: `Cache` lazily conjured a connection + transaction on first use and held it for its whole lifetime, and everything else that needed the DB borrowed it. That ownership inversion is what produced the long-lived transactions seen in production — one transaction held open for an entire run, starving Postgres autovacuum and bloating the cache/resolver tables.

This puts ownership right-side-up: **the owner of a unit of work owns the session; data-access objects are handed one.**

## What

**`nomenklatura.db.Session`** — a thin unit-of-work wrapper over a single Core `Connection` in SQLAlchemy 2.0 commit-as-you-go mode (not the ORM `Session`). It owns connection lifetime and dialect, nothing else:
- `checkpoint()` — commit and keep the connection (frequent-cadence primitive; the next `execute` re-begins, so no transaction stays open for a whole run)
- `commit()` — commit and dispose; `rollback()` / `close()`; context-manager semantics (commit on clean exit, rollback+close on error)
- `create(*tables)` — DDL on the live connection, metadata-agnostic
- `make_session(url)` reuses the shared engine pool but hands back a fresh connection.

**`Cache` and `Resolver` are now pure consumers** — each runs on an injected session, owns a fresh `MetaData`, and no longer self-begins, swallows errors, or commits. `Cache.flush()/close()/make_default()` and `Resolver.begin()/commit()/rollback()/close()/make_default()` are gone; the **owner** commits. `Resolver.begin(load_edges=True)` splits into `load_into_memory()` (load the graph) and the owner's commit; `Resolver.cleanup_dead_edges()` is removed entirely (superseded NO_JUDGEMENT rows are reclaimed by `prune()`, run regularly, not on every commit).

**Call sites migrated** — the CLI commands, `xref`, the wikidata reconcile functions, and both TUIs own a session and thread it through (`xref(resolver, session, …)`, `reconcile_ui(resolver, session, …)`, `dedupe_ui(resolver, session, …)`); per-judgement `commit()` becomes `session.checkpoint()`. The wikidata-reconcile and match/enrich commands now share **one** session between cache and resolver.

**First read-and-release** — `xref` issues `session.checkpoint()` immediately after `load_into_memory()`, so the load's read transaction is released before the scoring scan instead of pinned across it.

**Tests** — a `db_session` fixture (one per test, disposed on teardown, so no test leaks an open transaction) and a `cache_factory` replacing `Cache.make_default(dataset)`.

## Scope / follow-ups

- The entity **`SQLStore`** is not migrated — its reads legitimately stream on dedicated connections, so it won't fold into a shared session (it'll take a `Session` only for its engine, later).
- **Read-and-release everywhere** — `xref` does it; the read-only consumers (enrich, `apply`, store sync) still hold the load transaction for the run. Releasing them is the change that fully flattens the autovacuum dashboard, and is the next step.
- **zavod** consumes this; it's migrated separately (the Context will own one session shared by cache + resolver + stateful tables).

## Testing

- Full suite: 233 passed
- `mypy --strict`: clean (107 files)