### PR TITLE
Resolver: drop the in-memory edge graph; derive indexes from the DB

### DIFF
--- a/nomenklatura/db.py
+++ b/nomenklatura/db.py
@@ -17,7 +17,9 @@ from sqlalchemy import (
 )
 from sqlalchemy.engine import Connection, CursorResult, Dialect, Engine
 from sqlalchemy.sql.expression import Executable
+from sqlalchemy.dialects.postgresql import Insert as PostgreSQLInsert
 from sqlalchemy.dialects.postgresql import insert as psql_insert
+from sqlalchemy.dialects.sqlite import Insert as SQLiteInsert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
 from nomenklatura import settings
@@ -114,6 +116,16 @@ class Session:
 
     def execute(self, statement: Executable) -> CursorResult[Any]:
         return self.connection.execute(statement)
+
+    def insert(self, table: Table) -> PostgreSQLInsert | SQLiteInsert:
+        """Build an insert that supports the active database's upsert API."""
+        if self.is_sqlite:
+            return sqlite_insert(table)
+        if self.is_postgres:
+            return psql_insert(table)
+        raise NotImplementedError(
+            f"Upsert not implemented for dialect {self.dialect.name}"
+        )
 
     def create(self, *tables: Table) -> None:
         """Create the given tables on this session's connection."""

--- a/nomenklatura/resolver/linker.py
+++ b/nomenklatura/resolver/linker.py
@@ -17,6 +17,27 @@ class Linker(Generic[SE]):
     def __init__(self, mapping: Dict[str, Tuple[str, ...]]) -> None:
         self._mapping: Dict[str, Tuple[str, ...]] = mapping
 
+    def add(self, left: str, right: str) -> str:
+        """Fold a positive judgement into the cluster map, returning the canonical.
+
+        The single union primitive: merge the clusters of two IDs and re-point
+        every member at the merged tuple, canonical first. Idempotent — re-adding
+        an edge already inside a cluster rewrites the same tuple — which is what
+        lets the resolver replay a delta without tracking what it already saw.
+        This is the only mutation the map needs: incremental splits never happen,
+        a removed merge is handled by rebuilding the map from scratch.
+        """
+        idents = {left, right}
+        for node in (left, right):
+            cluster = self._mapping.get(node)
+            if cluster is not None:
+                idents.update(cluster)
+        # Sort via Identifier ordering (weight, id) so the canonical lands first.
+        members = tuple(i.id for i in sorted(map(Identifier.get, idents), reverse=True))
+        for node in members:
+            self._mapping[node] = members
+        return members[0]
+
     def connected(self, node: Identifier) -> Set[Identifier]:
         """Return all entities connected to the given node. Constructs Identifier
         objects on the fly from the internal string representation."""

--- a/nomenklatura/resolver/linker.py
+++ b/nomenklatura/resolver/linker.py
@@ -23,11 +23,12 @@ class Linker(Generic[SE]):
         Idempotence lets the resolver replay database updates without tracking
         which edges it has already applied.
         """
-        idents = {left, right}
+        idents: Set[str] = set()
         for node in (left, right):
             cluster = self._mapping.get(node)
             if cluster is not None:
                 idents.update(cluster)
+        idents.update((left, right))
         # Sort via Identifier ordering (weight, id) so the canonical lands first.
         members = tuple(i.id for i in sorted(map(Identifier.get, idents), reverse=True))
         for node in members:
@@ -37,10 +38,11 @@ class Linker(Generic[SE]):
     def connected(self, node: Identifier) -> Set[Identifier]:
         """Return all entities connected to the given node. Constructs Identifier
         objects on the fly from the internal string representation."""
-        cluster = self._mapping.get(node.id)
-        if cluster is None:
-            return {node}
-        return {Identifier.get(n) for n in cluster}
+        return {Identifier.get(n) for n in self.connected_ids(node.id)}
+
+    def connected_ids(self, entity_id: str) -> Tuple[str, ...]:
+        """Return the stored identifiers connected to an entity ID."""
+        return self._mapping.get(entity_id, (entity_id,))
 
     def get_canonical(self, entity_id: str) -> str:
         """Return the canonical identifier for the given entity ID."""

--- a/nomenklatura/resolver/linker.py
+++ b/nomenklatura/resolver/linker.py
@@ -18,14 +18,10 @@ class Linker(Generic[SE]):
         self._mapping: Dict[str, Tuple[str, ...]] = mapping
 
     def add(self, left: str, right: str) -> str:
-        """Fold a positive judgement into the cluster map, returning the canonical.
+        """Merge two identifier clusters and return their canonical.
 
-        The single union primitive: merge the clusters of two IDs and re-point
-        every member at the merged tuple, canonical first. Idempotent — re-adding
-        an edge already inside a cluster rewrites the same tuple — which is what
-        lets the resolver replay a delta without tracking what it already saw.
-        This is the only mutation the map needs: incremental splits never happen,
-        a removed merge is handled by rebuilding the map from scratch.
+        Idempotence lets the resolver replay database updates without tracking
+        which edges it has already applied.
         """
         idents = {left, right}
         for node in (left, right):

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -68,6 +68,12 @@ class Resolver(Linker[SE]):
             text("target"),
             **unique_kw,
         )
+        # Backs the candidate scan: NO_JUDGEMENT suggestions ordered by score.
+        suggested = Index(
+            f"{table_name}_judgement_score",
+            text("judgement"),
+            text("score"),
+        )
         self._table = Table(
             table_name,
             MetaData(),
@@ -80,6 +86,7 @@ class Resolver(Linker[SE]):
             Column("created_at", Unicode(28)),
             Column("deleted_at", Unicode(28), nullable=True),
             unique_pair,
+            suggested,
         )
         if create:
             session.create(self._table)

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -51,6 +51,15 @@ class Resolver(Linker[SE]):
         self._max_ts: Optional[str] = None
         self.edges: Dict[Pair, Edge] = {}
         self.nodes: Dict[Identifier, Set[Edge]] = defaultdict(set)
+        # Derived positive-cluster index for the hot reads. Maintained
+        # incrementally on positive adds; rebuilt wholesale after a positive
+        # edge is removed (rare), since the flat map cannot un-merge in place.
+        self._linker: Linker[SE] = Linker({})
+        self._linker_dirty = False
+        # Blocking judgements (negative/unsure) keyed by raw id pair. Raw keys
+        # never drift on merges, so this is maintained fully incrementally — a
+        # removed blocker is just a pop, no rebuild.
+        self._blockers: Dict[Pair, Judgement] = {}
 
         unique_kw: Dict[str, Any] = {"unique": True}
         if session.is_sqlite:
@@ -114,13 +123,35 @@ class Resolver(Linker[SE]):
             self.edges[edge.key] = edge
             self.nodes[edge.source].add(edge)
             self.nodes[edge.target].add(edge)
+            if edge.judgement == Judgement.POSITIVE:
+                self._linker.add(edge.source.id, edge.target.id)
+            elif edge.judgement in (Judgement.NEGATIVE, Judgement.UNSURE):
+                self._blockers[edge.key] = edge.judgement
         else:
-            self.edges.pop(edge.key, None)
+            existed = self.edges.pop(edge.key, None)
+            self._blockers.pop(edge.key, None)
             for node in (edge.source, edge.target):
                 if node in self.nodes:
                     self.nodes[node].discard(edge)
                     if len(self.nodes[node]) == 0:
                         del self.nodes[node]
+            # A removed positive edge may split a cluster; the flat map can't
+            # do that incrementally, so flag a rebuild on next read.
+            if existed is not None and existed.judgement == Judgement.POSITIVE:
+                self._linker_dirty = True
+
+    def _rebuild_linker(self) -> None:
+        linker: Linker[SE] = Linker({})
+        for edge in self.edges.values():
+            if edge.judgement == Judgement.POSITIVE:
+                linker.add(edge.source.id, edge.target.id)
+        self._linker = linker
+        self._linker_dirty = False
+
+    def _linker_view(self) -> Linker[SE]:
+        if self._linker_dirty:
+            self._rebuild_linker()
+        return self._linker
 
     def _invalidate(self) -> None:
         pass
@@ -138,7 +169,7 @@ class Resolver(Linker[SE]):
         """Return a linker object that can be used to resolve entities.
         This is less memory-consuming than the full resolver object.
         """
-        mapping: Dict[str, Tuple[str, ...]] = {}
+        linker: Linker[SE] = Linker({})
         stmt = self._table.select()
         stmt = stmt.where(self._table.c.judgement == Judgement.POSITIVE.value)
         stmt = stmt.where(self._table.c.deleted_at.is_(None))
@@ -146,41 +177,16 @@ class Resolver(Linker[SE]):
         cursor = self._session.execute(stmt)
         while batch := cursor.fetchmany(20000):
             for row in batch:
-                source_id: str = row.source
-                target_id: str = row.target
-                idents = set([Identifier.get(source_id), Identifier.get(target_id)])
-                sources = mapping.get(source_id)
-                if sources is not None:
-                    idents.update(Identifier.get(n) for n in sources)
-                targets = mapping.get(target_id)
-                if targets is not None:
-                    idents.update(Identifier.get(n) for n in targets)
-                cluster = tuple(i.id for i in sorted(idents, reverse=True))
-                for node in cluster:
-                    mapping[node] = cluster
+                linker.add(row.source, row.target)
         cursor.close()
-        return Linker(mapping)
+        return linker
 
     def get_edge(self, left_id: StrIdent, right_id: StrIdent) -> Optional[Edge]:
         key = Identifier.pair(left_id, right_id)
         return self.edges.get(key)
 
-    def _traverse(self, node: Identifier, seen: Set[Identifier]) -> Set[Identifier]:
-        """Returns the set of nodes connected to the given node via positive judgement."""
-        connected = set([node])
-        if node in seen:
-            return connected
-        seen.add(node)
-        for edge in self.nodes.get(node, []):
-            if edge.judgement == Judgement.POSITIVE:
-                other = edge.other(node)
-                rec = self._traverse(other, seen)
-                connected.update(rec)
-        return connected
-
-    # @lru_cache(maxsize=200000)
     def connected(self, node: Identifier) -> Set[Identifier]:
-        return self._traverse(node, set())
+        return self._linker_view().connected(node)
 
     def get_canonical(self, entity_id: str) -> str:
         """Return the canonical identifier for the given entity ID."""
@@ -231,12 +237,6 @@ class Resolver(Linker[SE]):
                 return edge
         return None
 
-    def _pair_judgement(self, left: Identifier, right: Identifier) -> Judgement:
-        edge = self.get_edge(left, right)
-        if edge is not None:
-            return edge.judgement
-        return Judgement.NO_JUDGEMENT
-
     def get_judgement(self, entity_id: StrIdent, other_id: StrIdent) -> Judgement:
         """Get the existing decision between two entities with dedupe factored in."""
         entity = Identifier.get(entity_id)
@@ -251,17 +251,14 @@ class Resolver(Linker[SE]):
         if is_qid(entity.id) and is_qid(other.id):
             return Judgement.NEGATIVE
 
-        # HACK: this would mark pairs only as unsure if the unsure judgement
-        # had been made on the current canonical combination:
-        # canon_edge = self._pair_judgement(max(entity_connected), max(other_connected))
-        # if canon_edge == Judgement.UNSURE:
-        #     return Judgement.UNSURE
-
+        # Any blocking (negative/unsure) edge spanning the two clusters decides
+        # the pair. A positive edge can't span them — it would have merged the
+        # clusters above — so only blockers remain to check.
         other_connected = self.connected(other)
         for e in entity_connected:
             for o in other_connected:
-                judgement = self._pair_judgement(e, o)
-                if judgement != Judgement.NO_JUDGEMENT:
+                judgement = self._blockers.get(Identifier.pair(e, o))
+                if judgement is not None:
                     return judgement
 
         return Judgement.NO_JUDGEMENT

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -161,10 +161,10 @@ class Resolver(Linker[SE]):
     def load_into_memory(self) -> None:
         """Load the in-memory indexes from the database.
 
-        Resolver reads use these indexes; call again to pick up database writes
-        made by another session.
+        Call this to pick up database writes made by another session. A full
+        rebuild is required because commit order can differ from write order.
         """
-        self._update_from_db()
+        self._load_all()
 
     def get_linker(self) -> Linker[SE]:
         """Return a linker object that can be used to resolve entities.

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -1,10 +1,11 @@
 #
-# Don't forget to call self._invalidate from methods that modify edges.
+# The in-memory state (the cluster linker and the blocker cache) is a pure
+# function of the table: write methods only touch the DB, then call
+# _update_from_db to refresh. Don't mutate the indexes directly.
 #
 from datetime import timedelta
 import getpass
 import logging
-from collections import defaultdict
 from typing import Any, Dict, Generator, List, Optional, Set, Tuple
 from rigour.ids.wikidata import is_qid
 from rigour.time import utc_now
@@ -49,16 +50,11 @@ class Resolver(Linker[SE]):
         self._session = session
         # The initial load only needs active edges.
         self._max_ts: Optional[str] = None
-        self.edges: Dict[Pair, Edge] = {}
-        self.nodes: Dict[Identifier, Set[Edge]] = defaultdict(set)
-        # Derived positive-cluster index for the hot reads. Maintained
-        # incrementally on positive adds; rebuilt wholesale after a positive
-        # edge is removed (rare), since the flat map cannot un-merge in place.
+        # In-memory indexes, both pure functions of the table refreshed by
+        # _update_from_db: the positive-merge cluster map that answers the hot
+        # reads, and a raw-keyed cache of blocking (negative/unsure) judgements.
+        # No full edge graph is held — suggestions live only in the table.
         self._linker: Linker[SE] = Linker({})
-        self._linker_dirty = False
-        # Blocking judgements (negative/unsure) keyed by raw id pair. Raw keys
-        # never drift on merges, so this is maintained fully incrementally — a
-        # removed blocker is just a pop, no rebuild.
         self._blockers: Dict[Pair, Judgement] = {}
 
         unique_kw: Dict[str, Any] = {"unique": True}
@@ -88,82 +84,80 @@ class Resolver(Linker[SE]):
         if create:
             session.create(self._table)
 
-    def _update_from_db(self) -> None:
-        """Apply new deletes and unseen edges from the database."""
-        stmt = self._table.select()
-        if self._max_ts is None:
-            stmt = stmt.where(self._table.c.deleted_at.is_(None))
-        else:
-            stmt = stmt.where(
-                or_(
-                    self._table.c.deleted_at > self._max_ts,
-                    self._table.c.created_at > self._max_ts,
-                )
-            )
-        stmt.order_by(self._table.c.deleted_at.asc().nulls_last())
-        stmt.order_by(self._table.c.created_at.asc())
+    def _index_edge(self, edge: Edge) -> None:
+        """Fold a single live edge into the in-memory indexes."""
+        if edge.judgement == Judgement.POSITIVE:
+            self._linker.add(edge.source.id, edge.target.id)
+        elif edge.judgement in (Judgement.NEGATIVE, Judgement.UNSURE):
+            self._blockers[edge.key] = edge.judgement
+
+    def _load_all(self) -> None:
+        """Rebuild both indexes from scratch over every live edge."""
+        self._linker = Linker({})
+        self._blockers = {}
+        max_ts: Optional[str] = None
+        stmt = self._table.select().where(self._table.c.deleted_at.is_(None))
         cursor = self._session.execute(stmt)
         while batch := cursor.fetchmany(10000):
             for row in batch:
                 edge = Edge.from_dict(row._mapping)
-                if self._max_ts is None:
-                    self._max_ts = edge.created_at
-                if self._max_ts is not None:
-                    if edge.created_at is not None:
-                        self._max_ts = max(self._max_ts, edge.created_at)
-                    if edge.deleted_at is not None:
-                        self._max_ts = max(self._max_ts, edge.deleted_at)
-                self._update_edge(edge)
+                if edge.created_at is not None:
+                    if max_ts is None or edge.created_at > max_ts:
+                        max_ts = edge.created_at
+                self._index_edge(edge)
         cursor.close()
+        self._max_ts = max_ts
 
-    def _update_edge(self, edge: Edge) -> None:
-        if edge.deleted_at is None:
-            if edge.judgement != Judgement.NO_JUDGEMENT:
-                edge.score = None
-            self.edges[edge.key] = edge
-            self.nodes[edge.source].add(edge)
-            self.nodes[edge.target].add(edge)
-            if edge.judgement == Judgement.POSITIVE:
-                self._linker.add(edge.source.id, edge.target.id)
-            elif edge.judgement in (Judgement.NEGATIVE, Judgement.UNSURE):
-                self._blockers[edge.key] = edge.judgement
+    def _update_from_db(self) -> None:
+        """Refresh the indexes from edges written since the last load.
+
+        Additive deltas (new positive merges, new blockers) fold straight in.
+        A soft-deleted positive edge can split a cluster, which the flat map
+        can't undo in place, so any such removal triggers a full rebuild;
+        deleted blockers are simply dropped. The window is inclusive
+        (``>= _max_ts``) and every apply is idempotent, so an edge written in
+        the same instant as the high-water mark is never missed nor double-
+        counted. Reads its own uncommitted writes via the shared connection.
+        """
+        if self._max_ts is None:
+            self._load_all()
+            return
+        stmt = self._table.select().where(
+            or_(
+                self._table.c.created_at >= self._max_ts,
+                self._table.c.deleted_at >= self._max_ts,
+            )
+        )
+        cursor = self._session.execute(stmt)
+        max_ts = self._max_ts
+        needs_rebuild = False
+        while batch := cursor.fetchmany(10000):
+            for row in batch:
+                edge = Edge.from_dict(row._mapping)
+                if edge.created_at is not None and edge.created_at > max_ts:
+                    max_ts = edge.created_at
+                if edge.deleted_at is not None:
+                    if edge.deleted_at > max_ts:
+                        max_ts = edge.deleted_at
+                    if edge.judgement == Judgement.POSITIVE:
+                        needs_rebuild = True
+                    else:
+                        self._blockers.pop(edge.key, None)
+                else:
+                    self._index_edge(edge)
+        cursor.close()
+        if needs_rebuild:
+            self._load_all()
         else:
-            existed = self.edges.pop(edge.key, None)
-            self._blockers.pop(edge.key, None)
-            for node in (edge.source, edge.target):
-                if node in self.nodes:
-                    self.nodes[node].discard(edge)
-                    if len(self.nodes[node]) == 0:
-                        del self.nodes[node]
-            # A removed positive edge may split a cluster; the flat map can't
-            # do that incrementally, so flag a rebuild on next read.
-            if existed is not None and existed.judgement == Judgement.POSITIVE:
-                self._linker_dirty = True
-
-    def _rebuild_linker(self) -> None:
-        linker: Linker[SE] = Linker({})
-        for edge in self.edges.values():
-            if edge.judgement == Judgement.POSITIVE:
-                linker.add(edge.source.id, edge.target.id)
-        self._linker = linker
-        self._linker_dirty = False
-
-    def _linker_view(self) -> Linker[SE]:
-        if self._linker_dirty:
-            self._rebuild_linker()
-        return self._linker
-
-    def _invalidate(self) -> None:
-        pass
+            self._max_ts = max_ts
 
     def load_into_memory(self) -> None:
-        """Populate the in-memory edge graph from the database.
+        """Load the in-memory indexes from the database.
 
-        Resolver reads use this graph; call again to pick up database writes
+        Resolver reads use these indexes; call again to pick up database writes
         made by another session.
         """
         self._update_from_db()
-        self._invalidate()
 
     def get_linker(self) -> Linker[SE]:
         """Return a linker object that can be used to resolve entities.
@@ -193,7 +187,7 @@ class Resolver(Linker[SE]):
         return Edge.from_dict(row._mapping)
 
     def connected(self, node: Identifier) -> Set[Identifier]:
-        return self._linker_view().connected(node)
+        return self._linker.connected(node)
 
     def get_canonical(self, entity_id: str) -> str:
         """Return the canonical identifier for the given entity ID."""
@@ -205,7 +199,7 @@ class Resolver(Linker[SE]):
 
     def canonicals(self) -> Generator[Identifier, None, None]:
         """Return all the canonical cluster identifiers."""
-        return self._linker_view().canonicals()
+        return self._linker.canonicals()
 
     def get_referents(self, canonical_id: str, canonicals: bool = True) -> Set[str]:
         """Get all the non-canonical entity identifiers which refer to a given
@@ -321,9 +315,7 @@ class Resolver(Linker[SE]):
         edge = self.get_edge(left_id, right_id)
         if edge is not None:
             if edge.judgement == Judgement.NO_JUDGEMENT:
-                # Just update score
-
-                # database
+                # Just update the score; a suggestion touches neither index.
                 stmt = update(self._table)
                 stmt = stmt.where(self._table.c.target == edge.target.id)
                 stmt = stmt.where(self._table.c.source == edge.source.id)
@@ -333,9 +325,6 @@ class Resolver(Linker[SE]):
                 )
                 stmt = stmt.values({"score": score})
                 self._session.execute(stmt)
-
-                # local state
-                edge.score = score
             return edge.target
         return self.decide(
             left_id, right_id, Judgement.NO_JUDGEMENT, score=score, user=user
@@ -349,6 +338,28 @@ class Resolver(Linker[SE]):
         user: Optional[str] = None,
         score: Optional[float] = None,
     ) -> Identifier:
+        result = self._decide(left_id, right_id, judgement, user=user, score=score)
+        # Suggestions don't touch the indexes; everything else does, so refresh
+        # so the caller's next read sees the merge/blocker it just wrote.
+        if judgement != Judgement.NO_JUDGEMENT:
+            self._update_from_db()
+        return result
+
+    def _decide(
+        self,
+        left_id: StrIdent,
+        right_id: StrIdent,
+        judgement: Judgement,
+        user: Optional[str] = None,
+        score: Optional[float] = None,
+    ) -> Identifier:
+        """Write a judgement to the table without refreshing the indexes.
+
+        Recurses to canonicalise positive matches; the public ``decide``
+        refreshes once at the end. The recursion only ever reads the endpoints
+        it is given against a fresh canonical, so the stale-during-recursion
+        index is never consulted for an edge written earlier in the same call.
+        """
         edge = self.get_edge(left_id, right_id)
         if edge is None:
             edge = Edge(left_id, right_id, judgement=judgement)
@@ -362,8 +373,8 @@ class Resolver(Linker[SE]):
             if not target.canonical:
                 canonical = Identifier.make()
                 self._remove_edge(edge)
-                self.decide(edge.source, canonical, judgement=judgement, user=user)
-                self.decide(edge.target, canonical, judgement=judgement, user=user)
+                self._decide(edge.source, canonical, judgement=judgement, user=user)
+                self._decide(edge.target, canonical, judgement=judgement, user=user)
                 return canonical
 
         edge.judgement = judgement
@@ -371,12 +382,10 @@ class Resolver(Linker[SE]):
         edge.user = user or getpass.getuser()
         edge.score = score or edge.score
         self._register(edge)
-        if judgement != Judgement.NO_JUDGEMENT:
-            self._invalidate()
         return edge.target
 
     def _register(self, edge: Edge) -> None:
-        """Ensure the edge exists in the resolver, as provided."""
+        """Write the edge to the table, superseding any live edge for the pair."""
         if edge.judgement != Judgement.NO_JUDGEMENT:
             edge.score = None
 
@@ -389,10 +398,9 @@ class Resolver(Linker[SE]):
 
         stmt = insert(self._table).values(edge.to_dict())
         self._session.execute(stmt)
-        self._update_edge(edge)
 
     def _remove_edge(self, edge: Edge) -> None:
-        """Remove an edge from the graph."""
+        """Soft-delete the live row for the edge's pair, if any."""
         edge.deleted_at = timestamp()
         stmt = update(self._table)
         stmt = stmt.values({"deleted_at": edge.deleted_at})
@@ -400,10 +408,9 @@ class Resolver(Linker[SE]):
         stmt = stmt.where(self._table.c.source == edge.source.id)
         stmt = stmt.where(self._table.c.deleted_at.is_(None))
         self._session.execute(stmt)
-        self._update_edge(edge)
 
     def _remove_node(self, node: Identifier) -> None:
-        """Remove a node from the graph."""
+        """Soft-delete every live edge touching the node."""
         deleted_at = timestamp()
         stmt = update(self._table)
         stmt = stmt.values({"deleted_at": deleted_at})
@@ -415,19 +422,11 @@ class Resolver(Linker[SE]):
         stmt = stmt.where(self._table.c.deleted_at.is_(None))
         self._session.execute(stmt)
 
-        edges = self.nodes.get(node)
-        if edges is None:
-            return
-        for edge in list(edges):
-            edge.deleted_at = deleted_at
-            if edge.judgement != Judgement.NO_JUDGEMENT:
-                self._update_edge(edge)
-
     def remove(self, node_id: StrIdent) -> None:
         """Remove all edges linking to the given node from the graph."""
         node = Identifier.get(node_id)
         self._remove_node(node)
-        self._invalidate()
+        self._update_from_db()
 
     def explode(self, node_id: StrIdent) -> Set[str]:
         """Dissolve all edges linked to the cluster to which the node belongs.
@@ -438,7 +437,7 @@ class Resolver(Linker[SE]):
         for part in self.connected(node):
             affected.add(str(part))
             self._remove_node(part)
-        self._invalidate()
+        self._update_from_db()
         return affected
 
     def prune(
@@ -446,97 +445,122 @@ class Resolver(Linker[SE]):
         cleanup_after: timedelta = timedelta(days=6 * 30),
         user: Optional[str] = None,
     ) -> None:
-        """Remove suggested (i.e. NO_JUDGEMENT) edges."""
-        # database
+        """Drop suggestions and simplify the merge graph, then refresh.
+
+        Three independent passes: discard NO_JUDGEMENT suggestions, redirect
+        positive edges that still point at a raw id onto their canonical, and
+        collapse old canonical-to-canonical intermediate merges. All three are
+        canonical-preserving — no node changes which cluster it resolves to —
+        so ``get_canonical`` stays valid against the pre-prune index throughout,
+        and a single refresh at the end rebuilds the simplified graph.
+        """
+        self._prune_suggestions(user=user)
+        self._prune_noncanonical_targets()
+        cutoff_ts = (utc_now() - cleanup_after).isoformat()[:28]
+        self._prune_intermediate_merges(cutoff_ts)
+        self._update_from_db()
+
+    def _live_edges(self, *conditions: Any) -> List[Edge]:
+        """Materialise the live edges matching the given column conditions."""
+        stmt = self._table.select().where(self._table.c.deleted_at.is_(None))
+        for condition in conditions:
+            stmt = stmt.where(condition)
+        cursor = self._session.execute(stmt)
+        edges = [Edge.from_dict(row._mapping) for row in cursor]
+        cursor.close()
+        return edges
+
+    def _prune_suggestions(self, user: Optional[str] = None) -> None:
+        """Hard-delete NO_JUDGEMENT suggestions (optionally for one user)."""
         stmt = delete(self._table)
         stmt = stmt.where(self._table.c.judgement == Judgement.NO_JUDGEMENT.value)
         if user is not None:
             stmt = stmt.where(self._table.c.user == user)
         self._session.execute(stmt)
 
-        # local state
+    def _prune_noncanonical_targets(self) -> None:
+        """Replace raw positive merge links with edges onto the canonical.
+
+        A positive edge whose target is a raw id bridges two members — e.g. a
+        member-to-member link that merged two existing clusters. Rewriting only
+        one endpoint onto the canonical can drop that bridge and split the
+        cluster when the endpoint already resolves to the winning canonical, so
+        attach *both* endpoints: connectivity is preserved whichever canonical
+        wins, and neither replacement edge has a raw target. The rewrites are
+        canonical-preserving, so ``get_canonical`` stays valid for the rest of
+        the pass against the pre-prune index.
+        """
         now = timestamp()
-        for edge in list(self.edges.values()):
-            if user is not None and edge.user != user:
+        positive = self._table.c.judgement == Judgement.POSITIVE.value
+        for edge in self._live_edges(positive):
+            if edge.target.canonical:
                 continue
-            if edge.judgement == Judgement.NO_JUDGEMENT:
-                edge.deleted_at = now
-                self._update_edge(edge)
-
-        cutoff = utc_now() - cleanup_after
-        cutoff_ts = cutoff.isoformat()[:28]
-
-        for edge in list(self.edges.values()):
-            if edge.deleted_at is not None:
+            canonical = Identifier.get(self.get_canonical(edge.target.id))
+            if not canonical.canonical:
+                log.warning("Invalid target: %s -> %s" % (edge.source, edge.target))
                 continue
+            log.info(
+                "Rewriting edge: %s = %s -> %s" % (edge.target, edge.source, canonical)
+            )
+            self._remove_edge(edge)
+            for member in (edge.source, edge.target):
+                self._register(
+                    Edge(
+                        left_id=member,
+                        right_id=canonical,
+                        judgement=Judgement.POSITIVE,
+                        user=edge.user,
+                        created_at=now,
+                    )
+                )
 
-            # Cleanup job 1: Positive merges where the target is not canonical.
-            if edge.judgement == Judgement.POSITIVE and not edge.target.canonical:
-                nu_target = Identifier.get(self.get_canonical(edge.target.id))
-                if not nu_target.canonical:
-                    log.warning("Invalid target: %s -> %s" % (edge.source, edge.target))
+    def _prune_intermediate_merges(self, cutoff_ts: str) -> None:
+        """Collapse old canonical-to-canonical merges onto the final canonical."""
+        now = timestamp()
+        positive = self._table.c.judgement == Judgement.POSITIVE.value
+        old = self._table.c.created_at < cutoff_ts
+        removed: Set[Pair] = set()
+        for edge in self._live_edges(positive, old):
+            if edge.key in removed:
+                continue
+            if not (edge.source.canonical and edge.target.canonical):
+                continue
+            canonical = Identifier.get(self.get_canonical(edge.source.id))
+            log.info(
+                "Removing intermediate merge: %s -> %s (%s)"
+                % (edge.source, edge.target, canonical)
+            )
+            touching = or_(
+                self._table.c.source == edge.source.id,
+                self._table.c.target == edge.source.id,
+            )
+            for linked_edge in self._live_edges(touching):
+                if linked_edge.key == edge.key or linked_edge.key in removed:
                     continue
-                log.info(
-                    "Rewriting edge: %s = %s -> %s"
-                    % (edge.target, edge.source, nu_target)
-                )
-                nu_edge = Edge(
-                    left_id=edge.source,
-                    right_id=nu_target,
-                    judgement=Judgement.POSITIVE,
-                    user=edge.user,
-                    created_at=now,
-                )
-                self._remove_edge(edge)
-                self._register(nu_edge)
-
-            # Cleanup job 2: Positive merges older than cutoff where both sides
-            # are canonical. These can be simplified and the intermediate canonical IDs
-            # removed.
-            if (
-                edge.source.canonical
-                and edge.target.canonical
-                and edge.judgement == Judgement.POSITIVE
-                and edge.created_at is not None
-                and edge.created_at < cutoff_ts
-            ):
-                canonical = Identifier.get(self.get_canonical(edge.source.id))
-                log.info(
-                    "Removing intermediate merge: %s -> %s (%s)"
-                    % (edge.source, edge.target, canonical)
-                )
-                linked = self.nodes.get(edge.source, set())
-                for linked_edge in list(linked):
-                    if linked_edge == edge:
-                        continue
-                    if linked_edge.deleted_at is not None:
-                        continue
-                    if linked_edge.other(edge.source) == canonical:
-                        log.warning(
-                            " -> Skipping self-referential edge: %s" % linked_edge
+                if linked_edge.other(edge.source) == canonical:
+                    log.warning(" -> Skipping self-referential edge: %s" % linked_edge)
+                else:
+                    log.info(
+                        " -> Rewriting edge: %s <-> %s -> %s (%s)"
+                        % (
+                            edge.source,
+                            linked_edge.other(edge.source),
+                            canonical,
+                            linked_edge.judgement,
                         )
-                    else:
-                        log.info(
-                            " -> Rewriting edge: %s <-> %s -> %s (%s)"
-                            % (
-                                edge.source,
-                                linked_edge.other(edge.source),
-                                canonical,
-                                linked_edge.judgement,
-                            )
-                        )
-                        nu_edge = Edge(
-                            left_id=linked_edge.other(edge.source),
-                            right_id=canonical,
-                            judgement=linked_edge.judgement,
-                            user=linked_edge.user,
-                            created_at=now,
-                        )
-                        self._register(nu_edge)
-                    self._remove_edge(linked_edge)
-                self._remove_edge(edge)
-
-        self._invalidate()
+                    )
+                    nu_edge = Edge(
+                        left_id=linked_edge.other(edge.source),
+                        right_id=canonical,
+                        judgement=linked_edge.judgement,
+                        user=linked_edge.user,
+                        created_at=now,
+                    )
+                    self._register(nu_edge)
+                self._remove_edge(linked_edge)
+                removed.add(linked_edge.key)
+            self._remove_edge(edge)
+            removed.add(edge.key)
 
     def apply_statement(self, stmt: Statement) -> Statement:
         """Canonicalise Statement Entity IDs and ID values"""
@@ -575,7 +599,7 @@ class Resolver(Linker[SE]):
                 if edge_count % 10000 == 0:
                     log.info("Loaded %s edges." % edge_count)
         log.info("Done. Loaded %s edges." % edge_count)
-        self._invalidate()
+        self._update_from_db()
 
     def __repr__(self) -> str:
         parts = self._session.engine.url

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -435,6 +435,45 @@ class Resolver(Linker[SE]):
         self._remove_node(node)
         self._update_from_db()
 
+    def rename_node(self, old_id: StrIdent, new_id: StrIdent) -> int:
+        """Rewrite every live edge touching an identifier to its replacement.
+
+        Use this when an external identifier has been merged upstream, for
+        example when Wikidata redirects one QID to another and downstream
+        resolver state should pretend the old QID never existed.
+        """
+        old = Identifier.get(old_id)
+        new = Identifier.get(new_id)
+        if old == new:
+            return 0
+
+        now = timestamp()
+        touching = or_(
+            self._table.c.source == old.id,
+            self._table.c.target == old.id,
+        )
+        changed = 0
+        for edge in self._live_edges(touching):
+            left = new if edge.target == old else edge.target
+            right = new if edge.source == old else edge.source
+            self._remove_edge(edge)
+            if left == right:
+                changed += 1
+                continue
+            self._register(
+                Edge(
+                    left_id=left,
+                    right_id=right,
+                    judgement=edge.judgement,
+                    score=edge.score,
+                    user=edge.user,
+                    created_at=now,
+                )
+            )
+            changed += 1
+        self._update_from_db()
+        return changed
+
     def explode(self, node_id: StrIdent) -> Set[str]:
         """Dissolve all edges linked to the cluster to which the node belongs.
         This is the hard way to make sure we re-do context once we realise

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -182,8 +182,15 @@ class Resolver(Linker[SE]):
         return linker
 
     def get_edge(self, left_id: StrIdent, right_id: StrIdent) -> Optional[Edge]:
-        key = Identifier.pair(left_id, right_id)
-        return self.edges.get(key)
+        (target, source) = Identifier.pair(left_id, right_id)
+        stmt = self._table.select()
+        stmt = stmt.where(self._table.c.target == target.id)
+        stmt = stmt.where(self._table.c.source == source.id)
+        stmt = stmt.where(self._table.c.deleted_at.is_(None))
+        row = self._session.execute(stmt).first()
+        if row is None:
+            return None
+        return Edge.from_dict(row._mapping)
 
     def connected(self, node: Identifier) -> Set[Identifier]:
         return self._linker_view().connected(node)
@@ -198,12 +205,7 @@ class Resolver(Linker[SE]):
 
     def canonicals(self) -> Generator[Identifier, None, None]:
         """Return all the canonical cluster identifiers."""
-        for node in self.nodes.keys():
-            if not node.canonical:
-                continue
-            canonical = self.get_canonical(node.id)
-            if canonical == node.id:
-                yield node
+        return self._linker_view().canonicals()
 
     def get_referents(self, canonical_id: str, canonicals: bool = True) -> Set[str]:
         """Get all the non-canonical entity identifiers which refer to a given
@@ -231,10 +233,9 @@ class Resolver(Linker[SE]):
             for o in right_connected:
                 if e == o:
                     continue
-                edge = self.edges.get(Identifier.pair(e, o))
-                if edge is None:
-                    continue
-                return edge
+                edge = self.get_edge(e, o)
+                if edge is not None:
+                    return edge
         return None
 
     def get_judgement(self, entity_id: StrIdent, other_id: StrIdent) -> Judgement:
@@ -287,10 +288,14 @@ class Resolver(Linker[SE]):
 
     def _get_suggested(self) -> List[Edge]:
         """Get all NO_JUDGEMENT edges in descending order of score."""
-        edges_all = self.edges.values()
-        candidates = (e for e in edges_all if e.judgement == Judgement.NO_JUDGEMENT)
-        cmp = lambda x: x.score or -1.0  # noqa
-        return sorted(candidates, key=cmp, reverse=True)
+        stmt = self._table.select()
+        stmt = stmt.where(self._table.c.judgement == Judgement.NO_JUDGEMENT.value)
+        stmt = stmt.where(self._table.c.deleted_at.is_(None))
+        stmt = stmt.order_by(self._table.c.score.desc().nulls_last())
+        cursor = self._session.execute(stmt)
+        edges = [Edge.from_dict(row._mapping) for row in cursor]
+        cursor.close()
+        return edges
 
     def get_candidates(
         self, limit: Optional[int] = None

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -326,23 +326,20 @@ class Resolver(Linker[SE]):
     ) -> Identifier:
         """Make a NO_JUDGEMENT link between two identifiers to suggest that a user
         should make a decision about whether they are the same or not."""
-        edge = self.get_edge(left_id, right_id)
-        if edge is not None:
-            if edge.judgement == Judgement.NO_JUDGEMENT:
-                # Just update the score; a suggestion touches neither index.
-                stmt = update(self._table)
-                stmt = stmt.where(self._table.c.target == edge.target.id)
-                stmt = stmt.where(self._table.c.source == edge.source.id)
-                stmt = stmt.where(self._table.c.deleted_at.is_(None))
-                stmt = stmt.where(
-                    self._table.c.judgement == Judgement.NO_JUDGEMENT.value
-                )
-                stmt = stmt.values({"score": score})
-                self._session.execute(stmt)
-            return edge.target
-        return self.decide(
-            left_id, right_id, Judgement.NO_JUDGEMENT, score=score, user=user
+        edge = Edge(left_id, right_id, judgement=Judgement.NO_JUDGEMENT)
+        edge.created_at = timestamp()
+        edge.user = user or getpass.getuser()
+        edge.score = score
+
+        stmt = self._session.insert(self._table).values(edge.to_dict())
+        stmt = stmt.on_conflict_do_update(
+            index_elements=[self._table.c.source, self._table.c.target],
+            index_where=self._table.c.deleted_at.is_(None),
+            set_={"score": stmt.excluded.score},
+            where=self._table.c.judgement == Judgement.NO_JUDGEMENT.value,
         )
+        self._session.execute(stmt)
+        return edge.target
 
     def decide(
         self,

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -50,10 +50,7 @@ class Resolver(Linker[SE]):
         self._session = session
         # The initial load only needs active edges.
         self._max_ts: Optional[str] = None
-        # In-memory indexes, both pure functions of the table refreshed by
-        # _update_from_db: the positive-merge cluster map that answers the hot
-        # reads, and a raw-keyed cache of blocking (negative/unsure) judgements.
-        # No full edge graph is held — suggestions live only in the table.
+        # Suggestions remain in the table; hot reads use these derived indexes.
         self._linker: Linker[SE] = Linker({})
         self._blockers: Dict[Pair, Judgement] = {}
 
@@ -116,15 +113,10 @@ class Resolver(Linker[SE]):
         self._max_ts = max_ts
 
     def _update_from_db(self) -> None:
-        """Refresh the indexes from edges written since the last load.
+        """Apply this session's recent writes to the indexes.
 
-        Additive deltas (new positive merges, new blockers) fold straight in.
-        A soft-deleted positive edge can split a cluster, which the flat map
-        can't undo in place, so any such removal triggers a full rebuild;
-        deleted blockers are simply dropped. The window is inclusive
-        (``>= _max_ts``) and every apply is idempotent, so an edge written in
-        the same instant as the high-water mark is never missed nor double-
-        counted. Reads its own uncommitted writes via the shared connection.
+        Removing a positive edge may split a cluster and requires a full rebuild.
+        Use ``load_into_memory`` to pick up writes from other sessions.
         """
         if self._max_ts is None:
             self._load_all()
@@ -346,8 +338,7 @@ class Resolver(Linker[SE]):
         score: Optional[float] = None,
     ) -> Identifier:
         result = self._decide(left_id, right_id, judgement, user=user, score=score)
-        # Suggestions don't touch the indexes; everything else does, so refresh
-        # so the caller's next read sees the merge/blocker it just wrote.
+        # Suggestions are not indexed in memory.
         if judgement != Judgement.NO_JUDGEMENT:
             self._update_from_db()
         return result
@@ -360,12 +351,9 @@ class Resolver(Linker[SE]):
         user: Optional[str] = None,
         score: Optional[float] = None,
     ) -> Identifier:
-        """Write a judgement to the table without refreshing the indexes.
+        """Write a judgement without refreshing the indexes.
 
-        Recurses to canonicalise positive matches; the public ``decide``
-        refreshes once at the end. The recursion only ever reads the endpoints
-        it is given against a fresh canonical, so the stale-during-recursion
-        index is never consulted for an edge written earlier in the same call.
+        Used recursively so ``decide`` can refresh once after canonicalisation.
         """
         edge = self.get_edge(left_id, right_id)
         if edge is None:
@@ -452,14 +440,10 @@ class Resolver(Linker[SE]):
         cleanup_after: timedelta = timedelta(days=6 * 30),
         user: Optional[str] = None,
     ) -> None:
-        """Drop suggestions and simplify the merge graph, then refresh.
+        """Drop suggestions and simplify the merge graph.
 
-        Three independent passes: discard NO_JUDGEMENT suggestions, redirect
-        positive edges that still point at a raw id onto their canonical, and
-        collapse old canonical-to-canonical intermediate merges. All three are
-        canonical-preserving — no node changes which cluster it resolves to —
-        so ``get_canonical`` stays valid against the pre-prune index throughout,
-        and a single refresh at the end rebuilds the simplified graph.
+        Rewrites preserve cluster membership, allowing one refresh after all
+        pruning passes complete.
         """
         self._prune_suggestions(user=user)
         self._prune_noncanonical_targets()
@@ -486,16 +470,10 @@ class Resolver(Linker[SE]):
         self._session.execute(stmt)
 
     def _prune_noncanonical_targets(self) -> None:
-        """Replace raw positive merge links with edges onto the canonical.
+        """Replace raw positive merge links with canonical links.
 
-        A positive edge whose target is a raw id bridges two members — e.g. a
-        member-to-member link that merged two existing clusters. Rewriting only
-        one endpoint onto the canonical can drop that bridge and split the
-        cluster when the endpoint already resolves to the winning canonical, so
-        attach *both* endpoints: connectivity is preserved whichever canonical
-        wins, and neither replacement edge has a raw target. The rewrites are
-        canonical-preserving, so ``get_canonical`` stays valid for the rest of
-        the pass against the pre-prune index.
+        Attach both endpoints to avoid splitting a cluster when one already
+        resolves to the winning canonical.
         """
         now = timestamp()
         positive = self._table.c.judgement == Judgement.POSITIVE.value

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
     Table,
     Unicode,
     or_,
+    select,
     text,
 )
 from sqlalchemy.sql.expression import delete, insert, update
@@ -52,7 +53,7 @@ class Resolver(Linker[SE]):
         self._max_ts: Optional[str] = None
         # Suggestions remain in the table; hot reads use these derived indexes.
         self._linker: Linker[SE] = Linker({})
-        self._blockers: Dict[Pair, Judgement] = {}
+        self._blockers: Dict[Tuple[str, str], Judgement] = {}
 
         unique_kw: Dict[str, Any] = {"unique": True}
         if session.is_sqlite:
@@ -88,27 +89,32 @@ class Resolver(Linker[SE]):
         if create:
             session.create(self._table)
 
-    def _index_edge(self, edge: Edge) -> None:
-        """Fold a single live edge into the in-memory indexes."""
-        if edge.judgement == Judgement.POSITIVE:
-            self._linker.add(edge.source.id, edge.target.id)
-        elif edge.judgement in (Judgement.NEGATIVE, Judgement.UNSURE):
-            self._blockers[edge.key] = edge.judgement
+    def _index_row(self, target: str, source: str, judgement: Judgement) -> None:
+        """Fold a live database row into the in-memory indexes."""
+        if judgement == Judgement.POSITIVE:
+            self._linker.add(source, target)
+        elif judgement in (Judgement.NEGATIVE, Judgement.UNSURE):
+            self._blockers[(target, source)] = judgement
 
     def _load_all(self) -> None:
         """Rebuild both indexes from scratch over every live edge."""
         self._linker = Linker({})
         self._blockers = {}
         max_ts: Optional[str] = None
-        stmt = self._table.select().where(self._table.c.deleted_at.is_(None))
+        stmt = select(
+            self._table.c.target,
+            self._table.c.source,
+            self._table.c.judgement,
+            self._table.c.created_at,
+        ).where(self._table.c.deleted_at.is_(None))
         cursor = self._session.execute(stmt)
         while batch := cursor.fetchmany(10000):
             for row in batch:
-                edge = Edge.from_dict(row._mapping)
-                if edge.created_at is not None:
-                    if max_ts is None or edge.created_at > max_ts:
-                        max_ts = edge.created_at
-                self._index_edge(edge)
+                target, source, judgement_, created_at = row
+                if created_at is not None:
+                    if max_ts is None or created_at > max_ts:
+                        max_ts = created_at
+                self._index_row(target, source, Judgement(judgement_))
         cursor.close()
         self._max_ts = max_ts
 
@@ -121,7 +127,13 @@ class Resolver(Linker[SE]):
         if self._max_ts is None:
             self._load_all()
             return
-        stmt = self._table.select().where(
+        stmt = select(
+            self._table.c.target,
+            self._table.c.source,
+            self._table.c.judgement,
+            self._table.c.created_at,
+            self._table.c.deleted_at,
+        ).where(
             or_(
                 self._table.c.created_at >= self._max_ts,
                 self._table.c.deleted_at >= self._max_ts,
@@ -132,18 +144,19 @@ class Resolver(Linker[SE]):
         needs_rebuild = False
         while batch := cursor.fetchmany(10000):
             for row in batch:
-                edge = Edge.from_dict(row._mapping)
-                if edge.created_at is not None and edge.created_at > max_ts:
-                    max_ts = edge.created_at
-                if edge.deleted_at is not None:
-                    if edge.deleted_at > max_ts:
-                        max_ts = edge.deleted_at
-                    if edge.judgement == Judgement.POSITIVE:
+                target, source, judgement_, created_at, deleted_at = row
+                judgement = Judgement(judgement_)
+                if created_at is not None and created_at > max_ts:
+                    max_ts = created_at
+                if deleted_at is not None:
+                    if deleted_at > max_ts:
+                        max_ts = deleted_at
+                    if judgement == Judgement.POSITIVE:
                         needs_rebuild = True
                     else:
-                        self._blockers.pop(edge.key, None)
+                        self._blockers.pop((target, source), None)
                 else:
-                    self._index_edge(edge)
+                    self._index_row(target, source, judgement)
         cursor.close()
         if needs_rebuild:
             self._load_all()
@@ -233,25 +246,27 @@ class Resolver(Linker[SE]):
 
     def get_judgement(self, entity_id: StrIdent, other_id: StrIdent) -> Judgement:
         """Get the existing decision between two entities with dedupe factored in."""
-        entity = Identifier.get(entity_id)
-        other = Identifier.get(other_id)
+        entity = str(entity_id)
+        other = str(other_id)
         if entity == other:
             return Judgement.POSITIVE
-        entity_connected = self.connected(entity)
+        entity_connected = self._linker.connected_ids(entity)
         if other in entity_connected:
             return Judgement.POSITIVE
         # Check QIDs after connected because we sometimes insert an edge to say
         # one QID is canonical for another. Not common but important.
-        if is_qid(entity.id) and is_qid(other.id):
+        if is_qid(entity) and is_qid(other):
             return Judgement.NEGATIVE
 
         # Any blocking (negative/unsure) edge spanning the two clusters decides
         # the pair. A positive edge can't span them — it would have merged the
         # clusters above — so only blockers remain to check.
-        other_connected = self.connected(other)
+        other_connected = self._linker.connected_ids(other)
         for e in entity_connected:
             for o in other_connected:
-                judgement = self._blockers.get(Identifier.pair(e, o))
+                judgement = self._blockers.get((e, o))
+                if judgement is None:
+                    judgement = self._blockers.get((o, e))
                 if judgement is not None:
                     return judgement
 

--- a/nomenklatura/tui/dedupe.py
+++ b/nomenklatura/tui/dedupe.py
@@ -45,7 +45,6 @@ class DedupeState(Generic[DS, SE]):
     def load(self) -> bool:
         self.left = None
         self.right = None
-        self.resolver.load_into_memory()
         for left_id, right_id, score in self.resolver.get_candidates():
             left_id = self.resolver.get_canonical(left_id)
             right_id = self.resolver.get_canonical(right_id)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -78,7 +78,6 @@ def test_resolver(resolver: Resolver[StatementEntity], db_session):
     # subsequent suggest() updates score
     assert (c1c2 := resolver.get_edge("c1", "c2")) and c1c2.score == 8.0
     ccn = resolver.decide("c1", "c2", Judgement.POSITIVE)
-    # positive decide() replaces the non-canon edge with two towards canonical
     assert resolver.get_edge("c1", "c2") is None
     assert (ccnc2 := resolver.get_edge(ccn, "c2")) and ccnc2.score is None
     assert resolver.get_edge(ccn, "c1") is not None
@@ -225,13 +224,7 @@ def test_linker_non_canonical_cluster():
 
 
 def test_update_from_db():
-    """
-    This tests that one resolver instance can load updates from the db made by
-    another instance.
-
-    On SQLite this is not concurrent - it only tests the update loading.
-    On Postgres this also tests transaction winners.
-    """
+    """Load committed decisions made by another resolver session."""
     session1 = make_session()
     r1 = Resolver(session1, create=True)
     # PostgreSQL locks the uncommitted table creation.
@@ -246,11 +239,7 @@ def test_update_from_db():
         canon_a = r1.decide("a1", "a2", Judgement.POSITIVE, user="r1")
         canon_b = r2.decide("b1", "b2", Judgement.POSITIVE, user="r2")
         assert set(r1.canonicals()) == {canon_a}
-        # decide() refreshes from the db. On Postgres the two sessions hold
-        # separate connections, so r2's refresh can't see r1's uncommitted edge
-        # and each sees only its own decision. In-memory sqlite shares one
-        # connection (SingletonThreadPool), so that isolation doesn't hold —
-        # only assert it where the transaction model provides it.
+        # PostgreSQL sessions cannot see each other's uncommitted decisions.
         if session2.is_postgres:
             assert set(r2.canonicals()) == {canon_b}
         else:
@@ -261,10 +250,8 @@ def test_update_from_db():
 
         r1.load_into_memory()
         r2.load_into_memory()
-        # They see each others' decisions
         assert set(r1.canonicals()) == {canon_a, canon_b}
         assert set(r2.canonicals()) == {canon_a, canon_b}
-        # Validity for delete check
         assert Identifier.get("a2") in r1.connected(canon_a)
         assert Identifier.get("b2") in r2.connected(canon_b)
         r1.remove("b2")
@@ -274,7 +261,6 @@ def test_update_from_db():
 
         r1.load_into_memory()
         r2.load_into_memory()
-        # They see each others' deletes
         assert Identifier.get("a2") not in r1.connected(canon_a)
         assert Identifier.get("b2") not in r2.connected(canon_b)
         session1.checkpoint()
@@ -300,8 +286,7 @@ def test_resolver_store_load(
             assert len(fh.readlines()) == 4
 
         other_table_resolver.load(path)
-        # All four dumped edges land as live judgements (the dump carries no
-        # deleted_at, so the removed a3 edge reloads live).
+        # Dumps do not preserve deletion metadata.
         assert len(list(other_table_resolver.get_judgements())) == 4
 
         edge = other_table_resolver.get_edge("a2", "b2")
@@ -336,9 +321,7 @@ def test_resolver_candidates(resolver: Resolver[StatementEntity], db_session):
 def test_prune_rewrites_noncanonical_target(
     resolver: Resolver[StatementEntity], db_session
 ):
-    # Merging two existing clusters via raw ids leaves a positive edge whose
-    # target is a raw (non-canonical) id. prune's first cleanup job rewrites it
-    # to point at the canonical.
+    # Merge two existing clusters through raw members.
     resolver.decide("a1", "a2", Judgement.POSITIVE)
     resolver.decide("b1", "b2", Judgement.POSITIVE)
     resolver.decide("a1", "b1", Judgement.POSITIVE)
@@ -351,8 +334,6 @@ def test_prune_rewrites_noncanonical_target(
 
     resolver.prune()
 
-    # The raw cross-edge is gone, connectivity is preserved, and no positive
-    # edge with a non-canonical target survives.
     assert resolver.get_edge("a1", "b1") is None
     canon2 = resolver.get_canonical("a1")
     assert all(resolver.get_canonical(n) == canon2 for n in ("a1", "a2", "b1", "b2"))
@@ -365,9 +346,7 @@ def test_prune_rewrites_noncanonical_target(
 def test_prune_simplifies_intermediate_merge(
     resolver: Resolver[StatementEntity], db_session
 ):
-    # A direct canonical<->canonical positive edge is an intermediate merge.
-    # prune's second job (past the cutoff) rewrites the members onto the final
-    # canonical and removes the intermediate edge.
+    # Merge two clusters through their canonical identifiers.
     canon_a = resolver.decide("a1", "a2", Judgement.POSITIVE)
     canon_b = resolver.decide("b1", "b2", Judgement.POSITIVE)
     resolver.decide(canon_a, canon_b, Judgement.POSITIVE)
@@ -376,10 +355,9 @@ def test_prune_simplifies_intermediate_merge(
     canon = resolver.get_canonical("a1")
     assert all(resolver.get_canonical(n) == canon for n in ("a2", "b1", "b2"))
 
-    # Negative cleanup window puts the cutoff in the future so fresh edges qualify.
+    # Put the cleanup cutoff in the future so fresh edges qualify.
     resolver.prune(cleanup_after=timedelta(days=-3650))
 
-    # The intermediate edge is gone and connectivity is preserved.
     assert resolver.get_edge(canon_a, canon_b) is None
     canon2 = resolver.get_canonical("a1")
     assert all(resolver.get_canonical(n) == canon2 for n in ("a1", "a2", "b1", "b2"))
@@ -439,6 +417,5 @@ def test_table_name(
     assert other_table_resolver.get_canonical("a1") == a_canon
     assert set(other_table_resolver.canonicals()) == {a_canon}
     assert other_table_resolver.get_edge("a1", a_canon) is not None
-    # Only this resolver's own two edges live in the other table.
     assert len(list(other_table_resolver.get_judgements())) == 2
     assert "another_table" in repr(other_table_resolver)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -327,6 +327,30 @@ def test_resolver_candidates(resolver: Resolver[StatementEntity], db_session):
     db_session.checkpoint()
 
 
+def test_rename_qid_node(resolver: Resolver[StatementEntity], db_session):
+    resolver.decide("os-1", "Q123", Judgement.POSITIVE)
+    resolver.decide("os-2", "Q456", Judgement.POSITIVE)
+    resolver.decide("os-3", "Q123", Judgement.NEGATIVE)
+    resolver.suggest("os-4", "Q123", 0.75, user="test")
+
+    assert resolver.get_canonical("os-1") == "Q123"
+    assert resolver.get_judgement("os-3", "Q123") == Judgement.NEGATIVE
+
+    assert resolver.rename_node("Q123", "Q789") == 3
+
+    assert resolver.get_canonical("os-1") == "Q789"
+    assert resolver.get_judgement("os-1", "Q789") == Judgement.POSITIVE
+    assert resolver.get_judgement("os-3", "Q789") == Judgement.NEGATIVE
+    assert resolver.get_judgement("os-3", "Q123") == Judgement.NO_JUDGEMENT
+    assert ("Q789", "os-4", 0.75) in list(resolver.get_candidates())
+    assert resolver.get_edge("os-1", "Q123") is None
+    assert resolver.get_edge("os-3", "Q123") is None
+    assert resolver.get_edge("os-4", "Q123") is None
+
+    assert resolver.get_canonical("os-2") == "Q456"
+    db_session.checkpoint()
+
+
 def test_prune_rewrites_noncanonical_target(
     resolver: Resolver[StatementEntity], db_session
 ):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -180,6 +180,8 @@ def test_linker(resolver: Resolver[StatementEntity], db_session):
     assert linker.get_canonical("c2") == "c2"
     assert linker.get_canonical("x1") == "x1"
     assert linker.get_canonical("a3") == "a3"
+    assert linker.connected_ids("a1") == linker._mapping["a1"]
+    assert linker.connected_ids("unknown") == ("unknown",)
 
     # get_referents with canonicals=False excludes NK- and QID entries
     refs_no_canon = linker.get_referents("Q123", canonicals=False)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -36,7 +36,8 @@ def test_resolver(resolver: Resolver[StatementEntity], db_session):
     a_canon = resolver.decide("a1", "a2", Judgement.POSITIVE)
     assert a_canon.canonical, a_canon
     assert Identifier.get("a2") in resolver.connected(Identifier.get("a1"))
-    assert set(n.id for n in resolver.nodes) == {"a1", "a2", a_canon.id}
+    cluster = resolver.connected(Identifier.get("a1"))
+    assert set(n.id for n in cluster) == {"a1", "a2", a_canon.id}
 
     assert resolver.get_judgement("a1", "a2") == Judgement.POSITIVE
     resolver.decide("b1", "b2", Judgement.POSITIVE)
@@ -74,18 +75,15 @@ def test_resolver(resolver: Resolver[StatementEntity], db_session):
     resolver.suggest("c1", "c2", 7.0)
     assert (c1c2 := resolver.get_edge("c1", "c2")) and c1c2.score == 7.0
     resolver.suggest("c1", "c2", 8.0)
-    edge_count = len(resolver.edges)
     # subsequent suggest() updates score
     assert (c1c2 := resolver.get_edge("c1", "c2")) and c1c2.score == 8.0
-    assert c1c2 in resolver.edges, resolver.edges
     ccn = resolver.decide("c1", "c2", Judgement.POSITIVE)
+    # positive decide() replaces the non-canon edge with two towards canonical
     assert resolver.get_edge("c1", "c2") is None
     assert (ccnc2 := resolver.get_edge(ccn, "c2")) and ccnc2.score is None
-    # positive decide() replaces non-canon edge with two towards canonical
-
-    assert ccnc2.key in resolver.edges, resolver.edges
-    assert c1c2.key not in resolver.edges, resolver.edges
-    assert len(resolver.edges) == edge_count + 1
+    assert resolver.get_edge(ccn, "c1") is not None
+    assert resolver.get_canonical("c1") == ccn
+    assert resolver.get_canonical("c2") == ccn
 
     assert "a1" in resolver.get_referents(a_canon.id)
     assert "a1" in resolver.get_referents(a_canon.id, canonicals=False)
@@ -248,7 +246,15 @@ def test_update_from_db():
         canon_a = r1.decide("a1", "a2", Judgement.POSITIVE, user="r1")
         canon_b = r2.decide("b1", "b2", Judgement.POSITIVE, user="r2")
         assert set(r1.canonicals()) == {canon_a}
-        assert set(r2.canonicals()) == {canon_b}
+        # decide() refreshes from the db. On Postgres the two sessions hold
+        # separate connections, so r2's refresh can't see r1's uncommitted edge
+        # and each sees only its own decision. In-memory sqlite shares one
+        # connection (SingletonThreadPool), so that isolation doesn't hold —
+        # only assert it where the transaction model provides it.
+        if session2.is_postgres:
+            assert set(r2.canonicals()) == {canon_b}
+        else:
+            assert canon_b in set(r2.canonicals())
         r1.suggest(canon_a, "a3", 1.0, "test user")
         session1.checkpoint()
         session2.checkpoint()
@@ -294,7 +300,9 @@ def test_resolver_store_load(
             assert len(fh.readlines()) == 4
 
         other_table_resolver.load(path)
-        assert len(other_table_resolver.edges) == len(resolver.edges)
+        # All four dumped edges land as live judgements (the dump carries no
+        # deleted_at, so the removed a3 edge reloads live).
+        assert len(list(other_table_resolver.get_judgements())) == 4
 
         edge = other_table_resolver.get_edge("a2", "b2")
         assert edge is not None, edge
@@ -431,5 +439,6 @@ def test_table_name(
     assert other_table_resolver.get_canonical("a1") == a_canon
     assert set(other_table_resolver.canonicals()) == {a_canon}
     assert other_table_resolver.get_edge("a1", a_canon) is not None
-    assert len(other_table_resolver.edges) == 2
+    # Only this resolver's own two edges live in the other table.
+    assert len(list(other_table_resolver.get_judgements())) == 2
     assert "another_table" in repr(other_table_resolver)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Dict, Tuple
@@ -321,6 +322,59 @@ def test_resolver_candidates(resolver: Resolver[StatementEntity], db_session):
     resolver.prune()
     candidates = list(resolver.get_candidates())
     assert len(candidates) == 0, candidates
+    db_session.checkpoint()
+
+
+def test_prune_rewrites_noncanonical_target(
+    resolver: Resolver[StatementEntity], db_session
+):
+    # Merging two existing clusters via raw ids leaves a positive edge whose
+    # target is a raw (non-canonical) id. prune's first cleanup job rewrites it
+    # to point at the canonical.
+    resolver.decide("a1", "a2", Judgement.POSITIVE)
+    resolver.decide("b1", "b2", Judgement.POSITIVE)
+    resolver.decide("a1", "b1", Judgement.POSITIVE)
+
+    cross = resolver.get_edge("a1", "b1")
+    assert cross is not None and cross.judgement == Judgement.POSITIVE, cross
+    assert not (cross.target.canonical and cross.source.canonical), cross
+    canon = resolver.get_canonical("a1")
+    assert all(resolver.get_canonical(n) == canon for n in ("a2", "b1", "b2"))
+
+    resolver.prune()
+
+    # The raw cross-edge is gone, connectivity is preserved, and no positive
+    # edge with a non-canonical target survives.
+    assert resolver.get_edge("a1", "b1") is None
+    canon2 = resolver.get_canonical("a1")
+    assert all(resolver.get_canonical(n) == canon2 for n in ("a1", "a2", "b1", "b2"))
+    for edge in resolver.get_judgements():
+        if edge.judgement == Judgement.POSITIVE:
+            assert edge.target.canonical, edge
+    db_session.checkpoint()
+
+
+def test_prune_simplifies_intermediate_merge(
+    resolver: Resolver[StatementEntity], db_session
+):
+    # A direct canonical<->canonical positive edge is an intermediate merge.
+    # prune's second job (past the cutoff) rewrites the members onto the final
+    # canonical and removes the intermediate edge.
+    canon_a = resolver.decide("a1", "a2", Judgement.POSITIVE)
+    canon_b = resolver.decide("b1", "b2", Judgement.POSITIVE)
+    resolver.decide(canon_a, canon_b, Judgement.POSITIVE)
+
+    assert resolver.get_edge(canon_a, canon_b) is not None
+    canon = resolver.get_canonical("a1")
+    assert all(resolver.get_canonical(n) == canon for n in ("a2", "b1", "b2"))
+
+    # Negative cleanup window puts the cutoff in the future so fresh edges qualify.
+    resolver.prune(cleanup_after=timedelta(days=-3650))
+
+    # The intermediate edge is gone and connectivity is preserved.
+    assert resolver.get_edge(canon_a, canon_b) is None
+    canon2 = resolver.get_canonical("a1")
+    assert all(resolver.get_canonical(n) == canon2 for n in ("a1", "a2", "b1", "b2"))
     db_session.checkpoint()
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -77,6 +77,13 @@ def test_resolver(resolver: Resolver[StatementEntity], db_session):
     resolver.suggest("c1", "c2", 8.0)
     # subsequent suggest() updates score
     assert (c1c2 := resolver.get_edge("c1", "c2")) and c1c2.score == 8.0
+    resolver.suggest("c1", "c2", 0.0)
+    assert (c1c2 := resolver.get_edge("c1", "c2")) and c1c2.score == 0.0
+    resolver.decide("guard1", "guard2", Judgement.NEGATIVE)
+    resolver.suggest("guard1", "guard2", 9.0)
+    assert (guard := resolver.get_edge("guard1", "guard2"))
+    assert guard.judgement == Judgement.NEGATIVE
+    assert guard.score is None
     ccn = resolver.decide("c1", "c2", Judgement.POSITIVE)
     assert resolver.get_edge("c1", "c2") is None
     assert (ccnc2 := resolver.get_edge(ccn, "c2")) and ccnc2.score is None


### PR DESCRIPTION
Stacked on #322 (targets `pudo/db-session`). Removes the duplication between the resolver's DB rows and its in-memory edge graph.

## What changes

The resolver no longer holds the full edge graph (`edges`/`nodes`). Its only in-memory state is now:
- a **positive-cluster `Linker`** (the hot reads — `connected`/`get_canonical`/`canonicals`/`get_referents`), maintained incrementally, and
- a **raw-keyed blocker cache** (`get_judgement`),

both pure functions of the table, refreshed by `_update_from_db` (incremental on `_max_ts`; full rebuild only when a positive edge is soft-deleted). Write methods touch only the DB and then refresh.

Headline effect: **NO_JUDGEMENT suggestions leave memory entirely** — in an xref run that's the bulk of the edges — and hot reads are O(1) off the linker instead of recomputing connectivity by DFS on every call.

## Notable pieces

- `Linker.add()` is the single union primitive, shared by `get_linker()` and the catch-up path.
- `get_edge`, `get_resolved_edge` and the candidate scan read the table directly; a `(judgement, score)` index backs the candidate sort.
- `decide` refreshes after non-suggestion writes so the caller sees its own merge. Correct on Postgres (per-session connections isolate uncommitted writes); the cross-instance test's pre-commit assertion is gated on Postgres, since in-memory SQLite shares one connection.
- `prune` is split into named passes (`_prune_suggestions` / `_prune_noncanonical_targets` / `_prune_intermediate_merges`) over DB-loaded working sets.

## Bug fix

The split surfaced a **pre-existing latent bug** in prune's non-canonical-target pass (confirmed flaky on the pre-refactor code): when two clusters were merged via a member-to-member edge, rewriting that raw bridge onto one endpoint's canonical could drop the bridge and split the merged cluster ~50% of the time, depending on random canonical ordering. Both endpoints are now attached to the canonical, preserving connectivity either way. Characterization tests pin both prune passes.

## Deployment note

The new `(judgement, score)` index is created automatically only for **freshly-created** resolver tables — `CREATE TABLE IF NOT EXISTS` does not add an index to a table that already exists. Existing deployments (the production resolver, the xref workspace) need it added manually to get the candidate-scan speedup:

```sql
CREATE INDEX IF NOT EXISTS resolver_judgement_score ON resolver (judgement, score);
```

(Substitute the table name if not the default `resolver`.)

## Tests

Full suite green (235 passed), `mypy --strict` clean. Tests that inspected `.edges`/`.nodes` internals were moved to the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)