### PR TITLE
Wikidata cache invalidation using modification date

### DIFF
--- a/nomenklatura/cache.py
+++ b/nomenklatura/cache.py
@@ -4,7 +4,7 @@ import logging
 from random import randint
 from dataclasses import dataclass
 from typing import Any, cast, Dict, Optional, Union, Generator
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from sqlalchemy import MetaData
 from sqlalchemy import Table, Column, DateTime, Unicode
 from sqlalchemy.future import select
@@ -14,7 +14,6 @@ from rigour.time import naive_now
 from followthemoney import Dataset
 
 from nomenklatura.db import Session
-
 
 log = logging.getLogger(__name__)
 Value = Union[str, None]
@@ -73,13 +72,31 @@ class Cache(object):
     def set_json(self, key: str, value: Any) -> None:
         return self.set(key, json.dumps(value))
 
-    def get(self, key: str, max_age: Optional[int] = None) -> Optional[Value]:
+    def get(
+        self,
+        key: str,
+        max_age: Optional[int] = None,
+        min_timestamp: Optional[datetime] = None,
+    ) -> Optional[Value]:
+        """Return the cached value for `key`, or None if there is no fresh entry.
+
+        `max_age` bounds staleness in days (with jitter via `randomize_cache`).
+        `min_timestamp` invalidates entries stored before that point in time —
+        use it when the caller knows the upstream resource has changed since.
+        When both are given, the stricter (later) cutoff wins.
+        """
         if max_age is not None and max_age < 1:
             return None
 
-        cache_cutoff = None
+        cache_cutoff: Optional[datetime] = None
         if max_age is not None:
             cache_cutoff = naive_now() - randomize_cache(max_age)
+        if min_timestamp is not None:
+            if min_timestamp.tzinfo is not None:
+                min_timestamp = min_timestamp.astimezone(timezone.utc)
+                min_timestamp = min_timestamp.replace(tzinfo=None)
+            if cache_cutoff is None or min_timestamp > cache_cutoff:
+                cache_cutoff = min_timestamp
 
         cache = self._preload.get(key)
         if cache is not None:

--- a/nomenklatura/cache.py
+++ b/nomenklatura/cache.py
@@ -73,16 +73,13 @@ class Cache(object):
     def set_json(self, key: str, value: Any) -> None:
         return self.set(key, json.dumps(value))
 
-    def get(
-        self, key: str, max_age: Optional[int] = None, randomize: bool = True
-    ) -> Optional[Value]:
+    def get(self, key: str, max_age: Optional[int] = None) -> Optional[Value]:
         if max_age is not None and max_age < 1:
             return None
 
         cache_cutoff = None
         if max_age is not None:
-            delta = randomize_cache(max_age) if randomize else timedelta(days=max_age)
-            cache_cutoff = naive_now() - delta
+            cache_cutoff = naive_now() - randomize_cache(max_age)
 
         cache = self._preload.get(key)
         if cache is not None:

--- a/nomenklatura/wikidata/client.py
+++ b/nomenklatura/wikidata/client.py
@@ -45,12 +45,7 @@ class WikidataClient(object):
         # self.cache.preload(f"{self.LABEL_PREFIX}%")
 
     @lru_cache(maxsize=MEMO_SMALL)
-    def fetch_item(
-        self,
-        qid: str,
-        cache_days: Optional[int] = None,
-        randomize: bool = True,
-    ) -> Optional[Item]:
+    def fetch_item(self, qid: str, cache_days: Optional[int] = None) -> Optional[Item]:
         # https://www.mediawiki.org/wiki/Wikibase/API
         # https://www.wikidata.org/w/api.php?action=help&modules=wbgetentities
         params = {
@@ -62,7 +57,7 @@ class WikidataClient(object):
         }
         url = build_url(self.WD_API, params=params)
         cache_days = cache_days or self.cache_days
-        raw = self.cache.get(url, max_age=cache_days, randomize=randomize)
+        raw = self.cache.get(url, max_age=cache_days)
         if raw is None:
             log.debug(
                 "Cache MISS fetching Wikidata item: %s cache_days=%s", qid, cache_days
@@ -82,7 +77,7 @@ class WikidataClient(object):
         item = Item(self, entity)
         if item.id != qid:
             # Redirected/merged item:
-            return self.fetch_item(item.id, cache_days=cache_days, randomize=randomize)
+            return self.fetch_item(item.id, cache_days=cache_days)
         return item
 
     @lru_cache(maxsize=100000)
@@ -112,21 +107,14 @@ class WikidataClient(object):
         self.cache.set_json(cache_key, label.pack())
         return label
 
-    def query(
-        self, query_text: str, cache_days: Optional[int] = None
-    ) -> SparqlResponse:
-        """Query the Wikidata SPARQL endpoint.
-
-        Args:
-          cache_days: overrides the client-level default for this call.
-        """
+    def query(self, query_text: str) -> SparqlResponse:
+        """Query the Wikidata SPARQL endpoint."""
         clean_text = squash_spaces(query_text)
         if len(clean_text) == 0:
             raise RuntimeError("Invalid query: %r" % query_text)
         params = {"query": clean_text}
         url = build_url(self.QUERY_API, params=params)
-        effective_cache = cache_days if cache_days is not None else self.cache_days
-        raw = self.cache.get(url, max_age=effective_cache)
+        raw = self.cache.get(url, max_age=self.cache_days)
         if raw is None:
             headers = {"Accept": "application/sparql-results+json"}
             res = self.session.get(url, headers=headers)
@@ -138,9 +126,7 @@ class WikidataClient(object):
         except json.JSONDecodeError as err:
             self.cache.delete(url)
             log.exception("Failed to parse JSON: %s", err)
-            return SparqlResponse(
-                clean_text, {"head": {"vars": []}, "results": {"bindings": []}}
-            )
+            return SparqlResponse(clean_text, {})
         return SparqlResponse(clean_text, data)
 
     def search_items(

--- a/nomenklatura/wikidata/client.py
+++ b/nomenklatura/wikidata/client.py
@@ -71,7 +71,10 @@ class WikidataClient(object):
         raw = self.cache.get(url, max_age=cache_days, min_timestamp=modified_at)
         if raw is None:
             log.debug(
-                "Cache MISS fetching Wikidata item: %s cache_days=%s", qid, cache_days
+                "Cache MISS fetching Wikidata item: %s cache_days=%s modified_at=%s",
+                qid,
+                cache_days,
+                modified_at,
             )
             res = self.session.get(url)
             res.raise_for_status()
@@ -79,7 +82,10 @@ class WikidataClient(object):
             self.cache.set(url, raw)
         else:
             log.debug(
-                "Cache HIT fetching Wikidata item: %s cache_days=%s", qid, cache_days
+                "Cache HIT fetching Wikidata item: %s cache_days=%s modified_at=%s",
+                qid,
+                cache_days,
+                modified_at,
             )
         data = json.loads(raw)
         entity = data.get("entities", {}).get(qid)
@@ -120,20 +126,38 @@ class WikidataClient(object):
         self.cache.set_json(cache_key, label.pack())
         return label
 
-    def query(self, query_text: str) -> SparqlResponse:
-        """Query the Wikidata SPARQL endpoint."""
+    def query(
+        self, query_text: str, cache_days: Optional[int] = None
+    ) -> SparqlResponse:
+        """Query the Wikidata SPARQL endpoint.
+
+        Args:
+          cache_days: overrides the client-level default for this call.
+        """
         clean_text = squash_spaces(query_text)
         if len(clean_text) == 0:
             raise RuntimeError("Invalid query: %r" % query_text)
         params = {"query": clean_text}
         url = build_url(self.QUERY_API, params=params)
-        raw = self.cache.get(url, max_age=self.cache_days)
+        effective_cache = cache_days if cache_days is not None else self.cache_days
+        raw = self.cache.get(url, max_age=effective_cache)
         if raw is None:
+            log.debug(
+                "Cache MISS fetching Wikidata SPARQL query: %s cache_days=%s",
+                clean_text,
+                effective_cache,
+            )
             headers = {"Accept": "application/sparql-results+json"}
             res = self.session.get(url, headers=headers)
             res.raise_for_status()
             raw = res.text
             self.cache.set(url, raw)
+        else:
+            log.debug(
+                "Cache HIT fetching Wikidata SPARQL query: %s cache_days=%s",
+                clean_text,
+                effective_cache,
+            )
         try:
             data = json.loads(raw)
         except json.JSONDecodeError as err:

--- a/nomenklatura/wikidata/client.py
+++ b/nomenklatura/wikidata/client.py
@@ -94,6 +94,10 @@ class WikidataClient(object):
         item = Item(self, entity)
         if item.id != qid:
             # Redirected/merged item:
+            #
+            # The modification date doesn't relate to the new QID, but let's
+            # use it as its minimum age nonetheless since there's a good chance
+            # the replacement item was edited around the time the original was merged.
             return self.fetch_item(
                 item.id, cache_days=cache_days, modified_at=modified_at
             )
@@ -229,21 +233,6 @@ class WikidataClient(object):
             if qid is not None and is_qid(qid):
                 qids.append(qid)
         return qids
-
-    @lru_cache(maxsize=30000)
-    def _type_props(self, qid: str) -> List[str]:
-        item = self.fetch_item(qid)
-        if item is None:
-            return []
-        types: List[str] = []
-        for claim in item.claims:
-            # historical countries are always historical:
-            ended = claim.is_ended and claim.qid != "Q3024240"
-            if ended or claim.qid is None or claim.deprecated:
-                continue
-            if claim.property in ("P31", "P279"):
-                types.append(claim.qid)
-        return types
 
     def __repr__(self) -> str:
         return "<WikidataClient()>"

--- a/nomenklatura/wikidata/client.py
+++ b/nomenklatura/wikidata/client.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from datetime import datetime
 from functools import lru_cache
 from typing import Any, List, Optional, Dict, Set
 from requests import Session
@@ -45,9 +46,19 @@ class WikidataClient(object):
         # self.cache.preload(f"{self.LABEL_PREFIX}%")
 
     @lru_cache(maxsize=MEMO_SMALL)
-    def fetch_item(self, qid: str, cache_days: Optional[int] = None) -> Optional[Item]:
+    def fetch_item(
+        self,
+        qid: str,
+        cache_days: Optional[int] = None,
+        modified_at: Optional[datetime] = None,
+    ) -> Optional[Item]:
         # https://www.mediawiki.org/wiki/Wikibase/API
         # https://www.wikidata.org/w/api.php?action=help&modules=wbgetentities
+        #
+        # `modified_at` (typically the item's schema:dateModified) invalidates
+        # cache entries stored before that timestamp. This lets callers pin a
+        # fixed `cache_days` while still refetching items known to have changed
+        # upstream since the cached copy was written.
         params = {
             "format": "json",
             "ids": qid,
@@ -57,7 +68,7 @@ class WikidataClient(object):
         }
         url = build_url(self.WD_API, params=params)
         cache_days = cache_days or self.cache_days
-        raw = self.cache.get(url, max_age=cache_days)
+        raw = self.cache.get(url, max_age=cache_days, min_timestamp=modified_at)
         if raw is None:
             log.debug(
                 "Cache MISS fetching Wikidata item: %s cache_days=%s", qid, cache_days
@@ -77,7 +88,9 @@ class WikidataClient(object):
         item = Item(self, entity)
         if item.id != qid:
             # Redirected/merged item:
-            return self.fetch_item(item.id, cache_days=cache_days)
+            return self.fetch_item(
+                item.id, cache_days=cache_days, modified_at=modified_at
+            )
         return item
 
     @lru_cache(maxsize=100000)

--- a/nomenklatura/wikidata/model.py
+++ b/nomenklatura/wikidata/model.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 from normality import stringify
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 from rigour.langs import iso_639_alpha3
@@ -169,7 +171,10 @@ class Item(object):
         types = set([qid])
         if len(path) > 6:
             return types
-        for type_ in self.client._type_props(qid):
+
+        item = self if qid == self.id else self.client.fetch_item(qid)
+        assert item is not None, path
+        for type_ in _type_props(item):
             if type_ not in path:
                 types.update(self._types(path + [type_]))
         return types
@@ -184,3 +189,16 @@ class Item(object):
 
     def __hash__(self) -> int:
         return hash(self.id)
+
+
+@lru_cache(maxsize=30000)
+def _type_props(item: Item) -> List[str]:
+    types: List[str] = []
+    for claim in item.claims:
+        # historical countries are always historical:
+        ended = claim.is_ended and claim.qid != "Q3024240"
+        if ended or claim.qid is None or claim.deprecated:
+            continue
+        if claim.property in ("P31", "P279"):
+            types.append(claim.qid)
+    return types


### PR DESCRIPTION
Let callers to WikidataClient.fetch_item provide a modification date. Cached values older than the modification date are re-fetched.

Replaces `randomize: bool` since that's not used yet.