### PR TITLE
Remove _type_props lru_cache

### DIFF
--- a/nomenklatura/wikidata/model.py
+++ b/nomenklatura/wikidata/model.py
@@ -191,7 +191,6 @@ class Item(object):
         return hash(self.id)
 
 
-@lru_cache(maxsize=30000)
 def _type_props(item: Item) -> List[str]:
     types: List[str] = []
     for claim in item.claims:


### PR DESCRIPTION
item doesn't implement eq and is much bigger than the previous cache key of QIDs.

Let's see how fast python can iterate data structures before complicating things.