### PR TITLE
Stop caching transient Wikidata API errors as missing items

### DIFF
--- a/nomenklatura/wikidata/__init__.py
+++ b/nomenklatura/wikidata/__init__.py
@@ -1,9 +1,10 @@
-from nomenklatura.wikidata.client import WikidataClient
+from nomenklatura.wikidata.client import WikidataAPIError, WikidataClient
 from nomenklatura.wikidata.lang import LangText
 from nomenklatura.wikidata.model import Item, Claim
 from nomenklatura.wikidata.query import SparqlBinding, SparqlResponse, SparqlValue
 
 __all__ = [
+    "WikidataAPIError",
     "WikidataClient",
     "LangText",
     "Item",

--- a/nomenklatura/wikidata/client.py
+++ b/nomenklatura/wikidata/client.py
@@ -18,6 +18,15 @@ from nomenklatura.wikidata.query import SparqlResponse
 log = logging.getLogger(__name__)
 
 
+class WikidataAPIError(RuntimeError):
+    """The Wikidata API reported an in-band error (HTTP 200 with an `error` body).
+
+    Raised for transient failures — rate limiting, lag, internal errors — so
+    that callers fail loudly instead of mistaking an outage for a missing item.
+    A permanent `no-such-entity` response is not an error: it reads as a `None`
+    item and stays cached."""
+
+
 class WikidataClient(object):
     """Read items and labels from the Wikidata API and SPARQL endpoint.
 
@@ -88,8 +97,21 @@ class WikidataClient(object):
                 modified_at,
             )
         data = json.loads(raw)
-        entity = data.get("entities", {}).get(qid)
-        if entity is None:
+        entities = data.get("entities")
+        if entities is None:
+            # The API reports failures in-band with HTTP 200. A deleted or
+            # never-created QID is a permanent fact: keep the response cached
+            # and read it as "no such item". Anything else is transient, so
+            # drop it from the cache to make the next attempt refetch.
+            code = data.get("error", {}).get("code")
+            if code == "no-such-entity":
+                return None
+            self.cache.delete(url)
+            raise WikidataAPIError(
+                "Wikidata API error fetching %s: %r" % (qid, data.get("error"))
+            )
+        entity = entities.get(qid)
+        if entity is None or "missing" in entity:
             return None
         item = Item(self, entity)
         if item.id != qid:
@@ -119,8 +141,16 @@ class WikidataClient(object):
         res = self.session.get(url)
         res.raise_for_status()
         data: Dict[str, Any] = res.json()
-        entity = data.get("entities", {}).get(qid)
-        if entity is None:
+        entities = data.get("entities")
+        if entities is None:
+            code = data.get("error", {}).get("code")
+            if code == "no-such-entity":
+                return LangText(None)
+            raise WikidataAPIError(
+                "Wikidata API error fetching label %s: %r" % (qid, data.get("error"))
+            )
+        entity = entities.get(qid)
+        if entity is None or "missing" in entity:
             return LangText(None)
         labels = LangText.from_dict(entity.get("labels", {}))
         label = LangText.pick(labels)

--- a/nomenklatura/wikidata/model.py
+++ b/nomenklatura/wikidata/model.py
@@ -1,3 +1,4 @@
+import logging
 from functools import lru_cache
 
 from normality import stringify
@@ -9,6 +10,8 @@ from nomenklatura.wikidata.lang import LangText
 
 if TYPE_CHECKING:
     from nomenklatura.wikidata.client import WikidataClient
+
+log = logging.getLogger(__name__)
 
 
 class Snak(object):
@@ -173,7 +176,10 @@ class Item(object):
             return types
 
         item = self if qid == self.id else self.client.fetch_item(qid)
-        assert item is not None, path
+        if item is None:
+            # A deleted P31/P279 ancestor shouldn't break type expansion:
+            log.warning("Missing type ancestor item: %s (path: %r)", qid, path)
+            return types
         for type_ in _type_props(item):
             if type_ not in path:
                 types.update(self._types(path + [type_]))

--- a/tests/test_wikidata.py
+++ b/tests/test_wikidata.py
@@ -8,7 +8,7 @@ from nomenklatura.cache import Cache
 from nomenklatura.resolver import Resolver
 from nomenklatura.store import load_entity_file_store
 from nomenklatura.matching import EntityResolveRegression
-from nomenklatura.wikidata import LangText, WikidataClient
+from nomenklatura.wikidata import LangText, WikidataAPIError, WikidataClient
 from nomenklatura.wikidata.reconcile import candidate_proxy, reconcile
 from nomenklatura.enrich.wikidata import clean_wikidata_name
 
@@ -418,6 +418,69 @@ def test_reconcile_state_linked_skipped(tmp_path, resolver: Resolver[Entity], ca
         # No reviewable person; the linked one was enriched during load.
         assert state.start() is False
         assert state.person is None
+
+def test_fetch_item_no_such_entity(test_cache: Cache):
+    # A deleted/never-created QID is a permanent miss: None, and the error
+    # response stays cached so later runs don't refetch it.
+    error = {"error": {"code": "no-such-entity", "id": "Q404"}}
+    with requests_mock.Mocker(real_http=False) as m:
+        m.register_uri("GET", WikidataClient.WD_API, json=error)
+        client = WikidataClient(test_cache)
+        assert client.fetch_item("Q404") is None
+        assert m.call_count == 1
+        # A fresh client (empty lru) is served from the SQL cache:
+        client2 = WikidataClient(test_cache)
+        assert client2.fetch_item("Q404") is None
+        assert m.call_count == 1
+
+
+def test_fetch_item_transient_error(test_cache: Cache):
+    # Any other in-band API error raises and is evicted from the cache, so a
+    # transient failure can't masquerade as a missing item for cache_days.
+    error = {"error": {"code": "maxlag", "info": "database is lagged"}}
+    with requests_mock.Mocker(real_http=False) as m:
+        m.register_uri("GET", WikidataClient.WD_API, json=error)
+        client = WikidataClient(test_cache)
+        with pytest.raises(WikidataAPIError):
+            client.fetch_item("Q7747")
+    # The next attempt refetches and succeeds:
+    with requests_mock.Mocker(real_http=False) as m:
+        m.register_uri("GET", WikidataClient.WD_API, json=wd_read_response)
+        item = client.fetch_item("Q7747")
+        assert m.call_count == 1
+        assert item is not None
+        assert item.id == "Q7747"
+
+
+def test_types_missing_ancestor(test_cache: Cache):
+    # A deleted P31/P279 ancestor is skipped, not an AssertionError.
+    def handler(request, context):
+        # requests_mock lower-cases query string values:
+        qid = request.qs["ids"][0].upper()
+        if qid == "Q1000":
+            claim = {
+                "id": "Q1000$1",
+                "rank": "normal",
+                "mainsnak": {
+                    "snaktype": "value",
+                    "property": "P31",
+                    "datatype": "wikibase-item",
+                    "datavalue": {
+                        "type": "wikibase-entityid",
+                        "value": {"id": "Q2000"},
+                    },
+                },
+            }
+            return {"entities": {"Q1000": {"id": "Q1000", "claims": {"P31": [claim]}}}}
+        return {"error": {"code": "no-such-entity", "id": qid}}
+
+    with requests_mock.Mocker(real_http=False) as m:
+        m.register_uri("GET", WikidataClient.WD_API, json=handler)
+        client = WikidataClient(test_cache)
+        item = client.fetch_item("Q1000")
+        assert item is not None
+        assert item.types == {"Q1000", "Q2000"}
+
 
 def test_model(test_cache: Cache):
     with requests_mock.Mocker(real_http=False) as m:


### PR DESCRIPTION
The Wikidata API reports failures in-band as HTTP 200 with an `{"error": ...}` body — for permanent conditions (`no-such-entity` on deleted/never-created QIDs) and transient ones (lag, rate limiting, internal errors) alike. `WikidataClient.fetch_item` cached any such response unconditionally and returned `None`, so a transient blip was served from cache as "this item doesn't exist" for up to `cache_days` (default 14, jittered to ~18). Verified against the live API: a nonexistent QID yields a 200 `no-such-entity` error body, not a `missing` entity.

Downstream this had a nasty compound effect: `Item._types` asserted `fetch_item()` results non-None, so a deleted (or error-cached) P31/P279 ancestor crashed the whole crawl with an `AssertionError` — repeatedly, until the cached error expired.

Changes:

- `fetch_item` and `get_label` now discriminate on the error code: `no-such-entity` stays cached and reads as a `None` item / empty label (permanent, cheap on re-runs); any other in-band error is evicted from the cache and raises the new `WikidataAPIError`, so crawls fail loudly instead of silently dropping entities for weeks. This matches the cleanup convention `_search_name` and `query()` already follow for malformed responses.
- With `None` now cleanly meaning "deleted item", `Item._types` skips a missing ancestor with a warning instead of asserting.
- An entity payload carrying a `missing` marker also reads as `None` instead of constructing an empty `Item`.
- `WikidataAPIError` is exported from `nomenklatura.wikidata` so crawlers can catch it explicitly.

Behavioral note for consumers: zavod crawlers and the enricher will now see `WikidataAPIError` propagate on transient API failures rather than quietly losing the affected entity — intended loud-failure semantics, but it means an API outage aborts a run instead of degrading silently.

Tests: permanent miss served from the SQL cache without a second API call; transient error raising, evicting the cache entry, and succeeding on retry; type expansion surviving a deleted P31 ancestor. All wikidata suites pass; `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)