### PR TITLE
Keep deprecated-rank claims out of Item.claims

### DIFF
--- a/nomenklatura/enrich/wikidata.py
+++ b/nomenklatura/enrich/wikidata.py
@@ -169,10 +169,6 @@ class WikidataEnricher(Enricher[DS]):
         if depth is None:
             depth = self.depth
         for claim in item.claims:
-            # Ignore all deprecated claims:
-            if claim.deprecated:
-                continue
-
             # TODO: memberships, employers?
             if claim.property in PROPS_FAMILY:
                 yield from self.make_link(

--- a/nomenklatura/wikidata/client.py
+++ b/nomenklatura/wikidata/client.py
@@ -5,6 +5,7 @@ from functools import lru_cache
 from typing import Any, List, Optional, Dict, Set
 from requests import Session
 from normality import squash_spaces
+from rigour.time import utc_now
 from rigour.urls import build_url
 from rigour.util import MEMO_SMALL
 from rigour.ids.wikidata import is_qid
@@ -45,13 +46,23 @@ class WikidataClient(object):
     LABEL_CACHE_DAYS = 100
 
     def __init__(
-        self, cache: Cache, session: Optional[Session] = None, cache_days: int = 14
+        self,
+        cache: Cache,
+        session: Optional[Session] = None,
+        cache_days: int = 14,
+        reference_time: Optional[datetime] = None,
     ) -> None:
         self.cache = cache
         # A bare session gets 403'd (default UA) and throttled by Wikidata, so
         # default to a configured session with a descriptive UA and retries.
         self.session = session or make_session()
         self.cache_days = cache_days
+        # The point in time against which claim validity is evaluated (see
+        # `Claim.is_ended`). Crawlers pass their pinned run time so a whole
+        # run resolves "ended" against one deterministic instant.
+        self.reference_time = (
+            reference_time if reference_time is not None else utc_now()
+        )
         # self.cache.preload(f"{self.LABEL_PREFIX}%")
 
     @lru_cache(maxsize=MEMO_SMALL)

--- a/nomenklatura/wikidata/model.py
+++ b/nomenklatura/wikidata/model.py
@@ -1,8 +1,10 @@
 import logging
+from datetime import datetime
 from functools import lru_cache
 
 from normality import stringify
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
+from rigour.dates import ended_before
 from rigour.langs import iso_639_alpha3
 
 from nomenklatura.wikidata.value import snak_value_to_string
@@ -77,11 +79,31 @@ class Claim(Snak):
     def get_qualifier(self, prop: str) -> List[Snak]:
         return self.qualifiers.get(prop, [])
 
-    @property
-    def is_ended(self) -> bool:
-        snak = self.qualifiers.get("P582")
-        if snak is not None and len(snak) > 0:
-            return True
+    def is_ended(self, reference_time: Optional[datetime] = None) -> bool:
+        """Whether the claim's validity period (P582) ended before
+        `reference_time`, defaulting to the client's run reference time.
+
+        A "no value" end time is Wikidata's way of asserting a claim is
+        current, and an imprecise end date only counts once its whole span
+        has elapsed — so a year-precision end in the current year is not
+        yet ended."""
+        if reference_time is None:
+            reference_time = self.client.reference_time
+        for snak in self.qualifiers.get("P582", []):
+            if snak.snaktype == "novalue":
+                continue
+            if snak.snaktype == "somevalue":
+                # Ended at an unknown date:
+                return True
+            text = snak.text.text
+            if text is None:
+                # An end is asserted, but the date didn't convert:
+                return True
+            try:
+                if ended_before(text, reference_time):
+                    return True
+            except ValueError:
+                return True
         return False
 
     def __repr__(self) -> str:
@@ -206,7 +228,7 @@ def _type_props(item: Item) -> List[str]:
     types: List[str] = []
     for claim in item.claims:
         # historical countries are always historical:
-        ended = claim.is_ended and claim.qid != "Q3024240"
+        ended = claim.is_ended() and claim.qid != "Q3024240"
         if ended or claim.qid is None:
             continue
         if claim.property in ("P31", "P279"):

--- a/nomenklatura/wikidata/model.py
+++ b/nomenklatura/wikidata/model.py
@@ -127,10 +127,15 @@ class Item(object):
         self.description = LangText.pick(descriptions)
 
         self.claims: List[Claim] = []
+        self.deprecated: List[Claim] = []
         claims: Dict[str, List[Dict[str, Any]]] = data.pop("claims", {})
         for prop, values in claims.items():
             for value in values:
-                self.claims.append(Claim(client, value, prop))
+                claim = Claim(client, value, prop)
+                if claim.deprecated:
+                    self.deprecated.append(claim)
+                else:
+                    self.claims.append(claim)
 
         # Merged pages handling:
         redirects = data.pop("redirects", {})
@@ -202,7 +207,7 @@ def _type_props(item: Item) -> List[str]:
     for claim in item.claims:
         # historical countries are always historical:
         ended = claim.is_ended and claim.qid != "Q3024240"
-        if ended or claim.qid is None or claim.deprecated:
+        if ended or claim.qid is None:
             continue
         if claim.property in ("P31", "P279"):
             types.append(claim.qid)

--- a/nomenklatura/wikidata/propose.py
+++ b/nomenklatura/wikidata/propose.py
@@ -59,8 +59,6 @@ class _Known:
 def _known_from_item(item: Item) -> _Known:
     known = _Known()
     for claim in item.claims:
-        if claim.deprecated:
-            continue
         if claim.property == "P31" and claim.qid == "Q5":
             known.is_human = True
         elif claim.property == "P569":

--- a/nomenklatura/wikidata/qualified.py
+++ b/nomenklatura/wikidata/qualified.py
@@ -8,8 +8,6 @@ from nomenklatura.wikidata.lang import LangText
 def qualify_value(value: LangText, claim: Claim) -> LangText:
     if value.text is None:
         return value
-    if claim.deprecated:
-        return value
     starts: Set[str] = set()
     for qual in claim.get_qualifier("P580"):
         if qual.text.text is not None:
@@ -26,5 +24,7 @@ def qualify_value(value: LangText, claim: Claim) -> LangText:
             dates.add(qual.text.text)
 
     label = post_summary(value.text, None, starts, ends, dates)
-    original = value.text or value.original
+    # Keep the QID (set by get_label) as the provenance for entity-valued
+    # claims, like every unqualified claim does:
+    original = value.original or value.text
     return LangText(label, value.lang, original=original)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 requires-python = ">= 3.11"
 dependencies = [
     "followthemoney >= 4.8.1, < 5.0.0",
-    "rigour >= 2.1.0, < 3.0.0",
+    "rigour >= 2.2.1, < 3.0.0",
     "fingerprints >= 1.3.1, < 2.0.0",
     "shortuuid >= 1.0.11, < 2.0.0",
     "rich >= 13.0.0, < 16.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 requires-python = ">= 3.11"
 dependencies = [
     "followthemoney >= 4.8.1, < 5.0.0",
-    "rigour >= 2.2.1, < 3.0.0",
+    "rigour >= 2.2.3, < 3.0.0",
     "fingerprints >= 1.3.1, < 2.0.0",
     "shortuuid >= 1.0.11, < 2.0.0",
     "rich >= 13.0.0, < 16.0.0",

--- a/tests/test_wikidata.py
+++ b/tests/test_wikidata.py
@@ -8,7 +8,7 @@ from nomenklatura.cache import Cache
 from nomenklatura.resolver import Resolver
 from nomenklatura.store import load_entity_file_store
 from nomenklatura.matching import EntityResolveRegression
-from nomenklatura.wikidata import LangText, WikidataAPIError, WikidataClient
+from nomenklatura.wikidata import Claim, LangText, WikidataAPIError, WikidataClient
 from nomenklatura.wikidata.reconcile import candidate_proxy, reconcile
 from nomenklatura.enrich.wikidata import clean_wikidata_name
 
@@ -480,6 +480,70 @@ def test_types_missing_ancestor(test_cache: Cache):
         item = client.fetch_item("Q1000")
         assert item is not None
         assert item.types == {"Q1000", "Q2000"}
+
+
+def _time_snak(prop: str, time: str, precision: int = 11):
+    return {
+        "snaktype": "value",
+        "property": prop,
+        "datatype": "time",
+        "datavalue": {"type": "time", "value": {"time": time, "precision": precision}},
+    }
+
+
+def test_item_deprecated_claims(test_cache: Cache):
+    # Deprecated rank marks known-wrong values; they parse into `deprecated`,
+    # not `claims`, so no consumer reads them as facts.
+    claims = {
+        "P569": [
+            {
+                "id": "Q3000$1",
+                "rank": "normal",
+                "mainsnak": _time_snak("P569", "+1952-10-07T00:00:00Z"),
+            },
+            {
+                "id": "Q3000$2",
+                "rank": "deprecated",
+                "mainsnak": _time_snak("P569", "+1852-10-07T00:00:00Z"),
+            },
+        ]
+    }
+    entity = {"entities": {"Q3000": {"id": "Q3000", "claims": claims}}}
+    with requests_mock.Mocker(real_http=False) as m:
+        m.register_uri("GET", WikidataClient.WD_API, json=entity)
+        client = WikidataClient(test_cache)
+        item = client.fetch_item("Q3000")
+        assert item is not None
+        assert [c.text.text for c in item.claims] == ["1952-10-07"]
+        assert len(item.deprecated) == 1
+        assert item.deprecated[0].text.text == "1852-10-07"
+
+
+def test_qualify_value(test_cache: Cache):
+    from nomenklatura.wikidata.qualified import qualify_value
+
+    client = WikidataClient(test_cache)
+    data = {
+        "id": "Q1$1",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": "P39",
+            "datatype": "wikibase-item",
+            "datavalue": {"type": "wikibase-entityid", "value": {"id": "Q30185"}},
+        },
+        "qualifiers": {
+            "P580": [_time_snak("P580", "+2010-01-01T00:00:00Z", precision=9)],
+            "P582": [_time_snak("P582", "+2015-06-01T00:00:00Z")],
+        },
+    }
+    claim = Claim(client, data, "P39")
+    value = LangText("Mayor", "eng", original="Q30185")
+    qualified = qualify_value(value, claim)
+    # Tenure dates are baked into the label; the QID stays as provenance:
+    assert qualified.text == "Mayor (2010-2015)"
+    assert qualified.original == "Q30185"
+    assert qualified.lang == "eng"
 
 
 def test_model(test_cache: Cache):

--- a/tests/test_wikidata.py
+++ b/tests/test_wikidata.py
@@ -519,6 +519,48 @@ def test_item_deprecated_claims(test_cache: Cache):
         assert item.deprecated[0].text.text == "1852-10-07"
 
 
+def test_claim_is_ended(test_cache: Cache):
+    from datetime import datetime, timezone
+
+    reference = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    client = WikidataClient(test_cache, reference_time=reference)
+    assert client.reference_time == reference
+
+    def claim_with_end(qualifier) -> Claim:
+        data = {
+            "id": "Q1$1",
+            "rank": "normal",
+            "mainsnak": {
+                "snaktype": "value",
+                "property": "P39",
+                "datatype": "wikibase-item",
+                "datavalue": {"type": "wikibase-entityid", "value": {"id": "Q2"}},
+            },
+            "qualifiers": {"P582": [qualifier]} if qualifier else {},
+        }
+        return Claim(client, data, "P39")
+
+    # No end qualifier at all:
+    assert claim_with_end(None).is_ended() is False
+    # An elapsed end date:
+    assert claim_with_end(_time_snak("P582", "+2015-06-01T00:00:00Z")).is_ended() is True
+    # "No value" asserts the claim is current:
+    novalue = {"snaktype": "novalue", "property": "P582", "datatype": "time"}
+    assert claim_with_end(novalue).is_ended() is False
+    # "Unknown value" means ended at an unknown date:
+    somevalue = {"snaktype": "somevalue", "property": "P582", "datatype": "time"}
+    assert claim_with_end(somevalue).is_ended() is True
+    # A scheduled future end is not yet ended:
+    assert claim_with_end(_time_snak("P582", "+2030-01-01T00:00:00Z")).is_ended() is False
+    # A year-precision end only counts once the year has elapsed:
+    current_year = _time_snak("P582", "+2026-00-00T00:00:00Z", precision=9)
+    assert claim_with_end(current_year).is_ended() is False
+    # An explicit reference overrides the client's:
+    later = datetime(2031, 1, 1, tzinfo=timezone.utc)
+    future = claim_with_end(_time_snak("P582", "+2030-01-01T00:00:00Z"))
+    assert future.is_ended(reference_time=later) is True
+
+
 def test_qualify_value(test_cache: Cache):
     from nomenklatura.wikidata.qualified import qualify_value
 


### PR DESCRIPTION
Stacked on #335 (branched from it; GitHub will retarget to `main` when that merges).

Deprecated rank is Wikidata's marker for known-wrong values — a debunked birth date, a corrected citizenship — recorded precisely so they *won't* be consumed as facts. Only four places in the codebase checked for it (`item_graph`, `_type_props`, `qualify_value`, `propose.py`); everything else imported deprecated claims as facts: the enricher's `item_proxy`, reconcile's `candidate_proxy`, and all zavod consumers (`wikidata_basic_human`, `wikidata_position`, country traversal, and both crawlers' P39 loops — which built Occupancy entities from deprecated "position held" claims).

The damage cut both ways: known-wrong birth dates and citizenships fed the matchers, and a deprecated claim could *veto* a real entity — a bogus pre-1900 birth date made `wikidata_basic_human` drop the whole person; a deprecated country claim pointing at a historical state killed a whole position.

Changes:

- `Item.__init__` splits deprecated-rank statements into a new `item.deprecated` list at parse time, so `item.claims` only carries usable facts. Every consumer across nomenklatura, zavod, and the crawlers inherits the filter with no changes on their side — fixing it per call site is how the inconsistency arose in the first place.
- The now-redundant per-consumer `claim.deprecated` checks are removed (`_type_props`, `item_graph`, `_known_from_item`). `propose.py` behavior is unchanged in effect: a deprecated birthdate still reads as "Wikidata lacks a birthdate", so we still propose our sourced value — the right edit.
- `qualify_value` cleanup: the `if claim.deprecated: return value` branch returned deprecated values *undecorated but still importable* — a half-measure, now mooted. And its `original = value.text or value.original` was dead code (the guard ensures `value.text` is non-None), which silently replaced the QID provenance with label text for position/education statements; flipped to `value.original or value.text` so they keep the QID as `original_value` like every other claim type.

Expected dataset effects: some entities lose values they shouldn't have had; some real people and positions reappear because deprecated claims no longer veto them.

Tests: parse-time split (normal P569 → `claims`, deprecated → `deprecated`) and `qualify_value` decoration + QID provenance. All wikidata suites pass (44 tests); `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)