### PR TITLE
Evaluate claim end dates as spans against a run reference

### DIFF
--- a/nomenklatura/wikidata/client.py
+++ b/nomenklatura/wikidata/client.py
@@ -5,6 +5,7 @@ from functools import lru_cache
 from typing import Any, List, Optional, Dict, Set
 from requests import Session
 from normality import squash_spaces
+from rigour.time import utc_now
 from rigour.urls import build_url
 from rigour.util import MEMO_SMALL
 from rigour.ids.wikidata import is_qid
@@ -45,13 +46,23 @@ class WikidataClient(object):
     LABEL_CACHE_DAYS = 100
 
     def __init__(
-        self, cache: Cache, session: Optional[Session] = None, cache_days: int = 14
+        self,
+        cache: Cache,
+        session: Optional[Session] = None,
+        cache_days: int = 14,
+        reference_time: Optional[datetime] = None,
     ) -> None:
         self.cache = cache
         # A bare session gets 403'd (default UA) and throttled by Wikidata, so
         # default to a configured session with a descriptive UA and retries.
         self.session = session or make_session()
         self.cache_days = cache_days
+        # The point in time against which claim validity is evaluated (see
+        # `Claim.is_ended`). Crawlers pass their pinned run time so a whole
+        # run resolves "ended" against one deterministic instant.
+        self.reference_time = (
+            reference_time if reference_time is not None else utc_now()
+        )
         # self.cache.preload(f"{self.LABEL_PREFIX}%")
 
     @lru_cache(maxsize=MEMO_SMALL)

--- a/nomenklatura/wikidata/model.py
+++ b/nomenklatura/wikidata/model.py
@@ -1,8 +1,10 @@
 import logging
+from datetime import datetime
 from functools import lru_cache
 
 from normality import stringify
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
+from rigour.dates import ended_before
 from rigour.langs import iso_639_alpha3
 
 from nomenklatura.wikidata.value import snak_value_to_string
@@ -77,11 +79,31 @@ class Claim(Snak):
     def get_qualifier(self, prop: str) -> List[Snak]:
         return self.qualifiers.get(prop, [])
 
-    @property
-    def is_ended(self) -> bool:
-        snak = self.qualifiers.get("P582")
-        if snak is not None and len(snak) > 0:
-            return True
+    def is_ended(self, reference_time: Optional[datetime] = None) -> bool:
+        """Whether the claim's validity period (P582) ended before
+        `reference_time`, defaulting to the client's run reference time.
+
+        A "no value" end time is Wikidata's way of asserting a claim is
+        current, and an imprecise end date only counts once its whole span
+        has elapsed — so a year-precision end in the current year is not
+        yet ended."""
+        if reference_time is None:
+            reference_time = self.client.reference_time
+        for snak in self.qualifiers.get("P582", []):
+            if snak.snaktype == "novalue":
+                continue
+            if snak.snaktype == "somevalue":
+                # Ended at an unknown date:
+                return True
+            text = snak.text.text
+            if text is None:
+                # An end is asserted, but the date didn't convert:
+                return True
+            try:
+                if ended_before(text, reference_time):
+                    return True
+            except ValueError:
+                return True
         return False
 
     def __repr__(self) -> str:
@@ -206,7 +228,7 @@ def _type_props(item: Item) -> List[str]:
     types: List[str] = []
     for claim in item.claims:
         # historical countries are always historical:
-        ended = claim.is_ended and claim.qid != "Q3024240"
+        ended = claim.is_ended() and claim.qid != "Q3024240"
         if ended or claim.qid is None:
             continue
         if claim.property in ("P31", "P279"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 requires-python = ">= 3.11"
 dependencies = [
     "followthemoney >= 4.8.1, < 5.0.0",
-    "rigour >= 2.1.0, < 3.0.0",
+    "rigour >= 2.2.1, < 3.0.0",
     "fingerprints >= 1.3.1, < 2.0.0",
     "shortuuid >= 1.0.11, < 2.0.0",
     "rich >= 13.0.0, < 16.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 requires-python = ">= 3.11"
 dependencies = [
     "followthemoney >= 4.8.1, < 5.0.0",
-    "rigour >= 2.2.1, < 3.0.0",
+    "rigour >= 2.2.3, < 3.0.0",
     "fingerprints >= 1.3.1, < 2.0.0",
     "shortuuid >= 1.0.11, < 2.0.0",
     "rich >= 13.0.0, < 16.0.0",

--- a/tests/test_wikidata.py
+++ b/tests/test_wikidata.py
@@ -519,6 +519,48 @@ def test_item_deprecated_claims(test_cache: Cache):
         assert item.deprecated[0].text.text == "1852-10-07"
 
 
+def test_claim_is_ended(test_cache: Cache):
+    from datetime import datetime, timezone
+
+    reference = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    client = WikidataClient(test_cache, reference_time=reference)
+    assert client.reference_time == reference
+
+    def claim_with_end(qualifier) -> Claim:
+        data = {
+            "id": "Q1$1",
+            "rank": "normal",
+            "mainsnak": {
+                "snaktype": "value",
+                "property": "P39",
+                "datatype": "wikibase-item",
+                "datavalue": {"type": "wikibase-entityid", "value": {"id": "Q2"}},
+            },
+            "qualifiers": {"P582": [qualifier]} if qualifier else {},
+        }
+        return Claim(client, data, "P39")
+
+    # No end qualifier at all:
+    assert claim_with_end(None).is_ended() is False
+    # An elapsed end date:
+    assert claim_with_end(_time_snak("P582", "+2015-06-01T00:00:00Z")).is_ended() is True
+    # "No value" asserts the claim is current:
+    novalue = {"snaktype": "novalue", "property": "P582", "datatype": "time"}
+    assert claim_with_end(novalue).is_ended() is False
+    # "Unknown value" means ended at an unknown date:
+    somevalue = {"snaktype": "somevalue", "property": "P582", "datatype": "time"}
+    assert claim_with_end(somevalue).is_ended() is True
+    # A scheduled future end is not yet ended:
+    assert claim_with_end(_time_snak("P582", "+2030-01-01T00:00:00Z")).is_ended() is False
+    # A year-precision end only counts once the year has elapsed:
+    current_year = _time_snak("P582", "+2026-00-00T00:00:00Z", precision=9)
+    assert claim_with_end(current_year).is_ended() is False
+    # An explicit reference overrides the client's:
+    later = datetime(2031, 1, 1, tzinfo=timezone.utc)
+    future = claim_with_end(_time_snak("P582", "+2030-01-01T00:00:00Z"))
+    assert future.is_ended(reference_time=later) is True
+
+
 def test_qualify_value(test_cache: Cache):
     from nomenklatura.wikidata.qualified import qualify_value
 


### PR DESCRIPTION
Third in the stack: #335 → #336 → this (GitHub retargets the base as each merges).

`Claim.is_ended` treated any P582 (end time) qualifier as "ended". That misread two things:

- A **"no value"** end time is Wikidata's way of asserting a claim is *current* — the exact opposite of ended. Items whose P31/P279 or country claims carried explicit no-end markers had types pruned as historical.
- A **dated end in the future** (a term scheduled to end in 2030) or an imprecise end covering the present (year-precision `2026`, mid-2026) also counted as ended.

Changes:

- `is_ended` becomes a method that discriminates snak types — `novalue` = current, `somevalue` = ended at an unknown date — and evaluates dated ends as half-open intervals via `rigour.dates.ended_before`: an imprecise end only counts once its whole span has elapsed, a future end not at all. An asserted end whose date doesn't convert still counts as ended, preserving the old conservative behavior for that case.
- The reference instant defaults to a new `WikidataClient.reference` (constructor param, defaulting to `rigour.time.utc_now()`), with a per-call override. This lets crawlers pin their run time so one crawl resolves "ended" against a single deterministic instant — the zavod side (passing `settings.RUN_TIME` in wd_peps/wd_categories and switching `_crawl_item_countries`' raw P582 presence checks to `claim.is_ended()`) follows in an opensanctions PR once this is released.
- rigour floor bumped to `>= 2.2.1` for `rigour.dates`.

Tests cover all six qualifier cases (absent, elapsed, novalue, somevalue, future, current-year span) against a pinned reference, plus the per-call override. All wikidata suites pass; `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)