### PR TITLE
Retry transient Wikidata API errors, then skip the item

### DIFF
--- a/nomenklatura/wikidata/__init__.py
+++ b/nomenklatura/wikidata/__init__.py
@@ -1,10 +1,9 @@
-from nomenklatura.wikidata.client import WikidataAPIError, WikidataClient
+from nomenklatura.wikidata.client import WikidataClient
 from nomenklatura.wikidata.lang import LangText
 from nomenklatura.wikidata.model import Item, Claim
 from nomenklatura.wikidata.query import SparqlBinding, SparqlResponse, SparqlValue
 
 __all__ = [
-    "WikidataAPIError",
     "WikidataClient",
     "LangText",
     "Item",

--- a/nomenklatura/wikidata/client.py
+++ b/nomenklatura/wikidata/client.py
@@ -1,8 +1,9 @@
 import json
+import time
 import logging
 from datetime import datetime
 from functools import lru_cache
-from typing import Any, List, Optional, Dict, Set
+from typing import Any, List, Optional, Set
 from requests import Session
 from normality import squash_spaces
 from rigour.time import utc_now
@@ -19,15 +20,6 @@ from nomenklatura.wikidata.query import SparqlResponse
 log = logging.getLogger(__name__)
 
 
-class WikidataAPIError(RuntimeError):
-    """The Wikidata API reported an in-band error (HTTP 200 with an `error` body).
-
-    Raised for transient failures — rate limiting, lag, internal errors — so
-    that callers fail loudly instead of mistaking an outage for a missing item.
-    A permanent `no-such-entity` response is not an error: it reads as a `None`
-    item and stays cached."""
-
-
 class WikidataClient(object):
     """Read items and labels from the Wikidata API and SPARQL endpoint.
 
@@ -41,6 +33,11 @@ class WikidataClient(object):
     CACHE_SHORT = 1
     CACHE_MEDIUM = CACHE_SHORT * 7
     CACHE_LONG = CACHE_SHORT * 30
+    # Retry budget for the transient in-band API errors Wikidata returns as
+    # HTTP 200 (see `_fetch_entities`). Class attributes so they stay tunable
+    # and test-overridable (set the backoff to 0 to skip real sleeps in tests).
+    API_MAX_ATTEMPTS = 3
+    API_RETRY_BACKOFF = 2.0  # seconds, exponential base: 2s, 4s between attempts
 
     LABEL_PREFIX = "wd:lb:"
     LABEL_CACHE_DAYS = 100
@@ -96,9 +93,12 @@ class WikidataClient(object):
                 cache_days,
                 modified_at,
             )
-            res = self.session.get(url)
-            res.raise_for_status()
-            raw = res.text
+            # `_fetch_entities` retries transient in-band errors; it returns
+            # None once they're exhausted (item skipped for this run) and
+            # otherwise a cacheable body, so nothing bad reaches the cache.
+            raw = self._fetch_entities(url)
+            if raw is None:
+                return None
             self.cache.set(url, raw)
         else:
             log.debug(
@@ -110,17 +110,9 @@ class WikidataClient(object):
         data = json.loads(raw)
         entities = data.get("entities")
         if entities is None:
-            # The API reports failures in-band with HTTP 200. A deleted or
-            # never-created QID is a permanent fact: keep the response cached
-            # and read it as "no such item". Anything else is transient, so
-            # drop it from the cache to make the next attempt refetch.
-            code = data.get("error", {}).get("code")
-            if code == "no-such-entity":
-                return None
-            self.cache.delete(url)
-            raise WikidataAPIError(
-                "Wikidata API error fetching %s: %r" % (qid, data.get("error"))
-            )
+            # Only a cached `no-such-entity` reaches here: a deleted or
+            # never-created QID is a permanent fact, read as "no such item".
+            return None
         entity = entities.get(qid)
         if entity is None or "missing" in entity:
             return None
@@ -136,6 +128,40 @@ class WikidataClient(object):
             )
         return item
 
+    def _fetch_entities(self, url: str) -> Optional[str]:
+        """GET a wbgetentities URL, retrying the transient errors Wikidata hides
+        in HTTP 200 bodies (DB lag, rate limits, internal errors).
+
+        Reach for this instead of a bare `session.get` for any wbgetentities
+        call: the session's status-code retries can't see an in-band 200 error,
+        so a single upstream blip would otherwise abort a whole crawl. Returns
+        the raw response text once it is cacheable — a populated `entities` map,
+        or a permanent `no-such-entity`. Returns None if a transient error
+        outlasts every retry: the caller then reads the item as absent for this
+        run, and, because nothing is cached, a later run refetches it.
+        """
+        error: Any = None
+        for attempt in range(self.API_MAX_ATTEMPTS):
+            res = self.session.get(url)
+            res.raise_for_status()
+            raw = res.text
+            data = json.loads(raw)
+            if data.get("entities") is not None:
+                return raw
+            error = data.get("error", {})
+            if error.get("code") == "no-such-entity":
+                return raw
+            log.warning(
+                "Transient Wikidata API error (attempt %d/%d): %r",
+                attempt + 1,
+                self.API_MAX_ATTEMPTS,
+                error,
+            )
+            if attempt + 1 < self.API_MAX_ATTEMPTS:
+                time.sleep(self.API_RETRY_BACKOFF * (2**attempt))
+        log.warning("Skipping %s after %d failed attempts: %r", url, attempt + 1, error)
+        return None
+
     @lru_cache(maxsize=100000)
     def get_label(self, qid: str) -> LangText:
         cache_key = f"{self.LABEL_PREFIX}{qid}"
@@ -149,17 +175,14 @@ class WikidataClient(object):
             "props": "labels",
         }
         url = build_url(self.WD_API, params=params)
-        res = self.session.get(url)
-        res.raise_for_status()
-        data: Dict[str, Any] = res.json()
-        entities = data.get("entities")
+        raw = self._fetch_entities(url)
+        if raw is None:
+            # Transient error outlasted the retries: treat the label as absent.
+            return LangText(None)
+        entities = json.loads(raw).get("entities")
         if entities is None:
-            code = data.get("error", {}).get("code")
-            if code == "no-such-entity":
-                return LangText(None)
-            raise WikidataAPIError(
-                "Wikidata API error fetching label %s: %r" % (qid, data.get("error"))
-            )
+            # Only a `no-such-entity` body reaches here (see `_fetch_entities`).
+            return LangText(None)
         entity = entities.get(qid)
         if entity is None or "missing" in entity:
             return LangText(None)

--- a/tests/test_wikidata.py
+++ b/tests/test_wikidata.py
@@ -8,7 +8,7 @@ from nomenklatura.cache import Cache
 from nomenklatura.resolver import Resolver
 from nomenklatura.store import load_entity_file_store
 from nomenklatura.matching import EntityResolveRegression
-from nomenklatura.wikidata import Claim, LangText, WikidataAPIError, WikidataClient
+from nomenklatura.wikidata import Claim, LangText, WikidataClient
 from nomenklatura.wikidata.reconcile import candidate_proxy, reconcile
 from nomenklatura.enrich.wikidata import clean_wikidata_name
 
@@ -435,21 +435,47 @@ def test_fetch_item_no_such_entity(test_cache: Cache):
 
 
 def test_fetch_item_transient_error(test_cache: Cache):
-    # Any other in-band API error raises and is evicted from the cache, so a
-    # transient failure can't masquerade as a missing item for cache_days.
+    # A persistent in-band API error is retried, then skipped (None) and never
+    # cached, so a transient failure can't masquerade as a missing item for
+    # cache_days: a later run refetches it.
     error = {"error": {"code": "maxlag", "info": "database is lagged"}}
     with requests_mock.Mocker(real_http=False) as m:
         m.register_uri("GET", WikidataClient.WD_API, json=error)
         client = WikidataClient(test_cache)
-        with pytest.raises(WikidataAPIError):
-            client.fetch_item("Q7747")
-    # The next attempt refetches and succeeds:
+        client.API_RETRY_BACKOFF = 0  # don't sleep between retries in tests
+        assert client.fetch_item("Q7747") is None
+        assert m.call_count == WikidataClient.API_MAX_ATTEMPTS
+    # A fresh client (empty lru) refetches from source and succeeds, proving the
+    # transient failure was not written to the SQL cache:
     with requests_mock.Mocker(real_http=False) as m:
         m.register_uri("GET", WikidataClient.WD_API, json=wd_read_response)
-        item = client.fetch_item("Q7747")
+        client2 = WikidataClient(test_cache)
+        item = client2.fetch_item("Q7747")
         assert m.call_count == 1
         assert item is not None
         assert item.id == "Q7747"
+
+
+def test_fetch_item_transient_recovers(test_cache: Cache):
+    # A transient error that clears within the retry budget resolves to the
+    # item in a single fetch_item call, without surfacing an exception.
+    error = {"error": {"code": "maxlag", "info": "database is lagged"}}
+    calls = {"n": 0}
+
+    def handler(request, context):
+        calls["n"] += 1
+        if calls["n"] < 2:
+            return error
+        return wd_read_response(request, context)
+
+    with requests_mock.Mocker(real_http=False) as m:
+        m.register_uri("GET", WikidataClient.WD_API, json=handler)
+        client = WikidataClient(test_cache)
+        client.API_RETRY_BACKOFF = 0  # don't sleep between retries in tests
+        item = client.fetch_item("Q7747")
+        assert item is not None
+        assert item.id == "Q7747"
+        assert m.call_count > 1
 
 
 def test_types_missing_ancestor(test_cache: Cache):


### PR DESCRIPTION
## Problem

The Wikidata / MediaWiki API reports internal failures — DB lag, rate limiting, `DBConnectionError` — **in-band as HTTP 200** with an `error` body. The session's status-code retries (`status_forcelist`) never see these, because the transport call itself succeeds. The error only surfaces one layer up, where `fetch_item`/`get_label` parse the body and find `entities is None`.

A single such transient blip on one QID recently aborted an entire multi-country `wd_peps` crawl.

## Change

Add `WikidataClient._fetch_entities(url)`, which GETs a `wbgetentities` URL and retries the transient in-band errors with exponential backoff (`API_MAX_ATTEMPTS = 3`, `API_RETRY_BACKOFF = 2.0` → 2s, 4s).

Once the retry budget is exhausted it **logs a warning and returns `None`** rather than raising. `fetch_item` then returns `None` (without caching it) and `get_label` returns an empty `LangText`, so:

- a transient outage no longer aborts the crawl — the item is read as absent for this run;
- nothing bad is written to the cache, so a **later run refetches** the item (the failure can't masquerade as a missing item for `cache_days`);
- callers need **no new error handling** — every `fetch_item` site already handles `None`.

A permanent `no-such-entity` remains a cached miss, exactly as before.

This also removes the now-unused `WikidataAPIError`. It existed only to force callers to fail loudly; the retry-then-skip behaviour supersedes it, and keeping it would just push error handling back out to every caller.

## Tests

- `test_fetch_item_transient_error`: a persistent error is retried `API_MAX_ATTEMPTS` times, resolves to `None`, and is **not** cached — a fresh client refetches from source and succeeds.
- `test_fetch_item_transient_recovers`: an error that clears within budget resolves to the item in a single `fetch_item` call.
- `test_fetch_item_no_such_entity` unchanged: `no-such-entity` returns on the first attempt, no retry, and stays cached.

`pytest tests/test_wikidata.py` (25 passed) and `mypy --strict` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)