### PR TITLE
Add indexes to lighten refresh from db

### DIFF
--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -90,8 +90,8 @@ class Resolver(Linker[SE]):
             Column("judgement", Unicode(14), nullable=False),
             Column("score", Float, nullable=True),
             Column("user", Unicode(512), nullable=False),
-            Column("created_at", Unicode(28)),
-            Column("deleted_at", Unicode(28), nullable=True),
+            Column("created_at", Unicode(28), index=True),
+            Column("deleted_at", Unicode(28), nullable=True, index=True),
             unique_pair,
             suggested,
         )


### PR DESCRIPTION
Fixes full table scan on
```sql
EXPLAIN (ANALYZE, BUFFERS)
   SELECT resolver.target, resolver.source, resolver.judgement, resolver.created_at, resolver.deleted_at
   FROM resolver
   WHERE resolver.created_at >= '2026-07-20T12:00'
      OR resolver.deleted_at >= '2026-07-20T12:00';
```

Called for every decide()

On deploy we need to run
  CREATE INDEX CONCURRENTLY ix_resolver_created_at ON resolver (created_at);
  CREATE INDEX CONCURRENTLY ix_resolver_deleted_at ON resolver (deleted_at);
  ANALYZE resolver;

@pudo I vaguely remember you saying something about indexes intentionally not added somewhere - this isn't it, is it? I imagine this will be ok since insertion is relatively rare except for dedupe, and even in dedupe, maintaining the indexes should be cheaper than full table scan.