### PR TITLE
Resolve enricher `topics` config once, expose as filter_topics

### DIFF
--- a/nomenklatura/enrich/common.py
+++ b/nomenklatura/enrich/common.py
@@ -4,7 +4,7 @@ import logging
 import traceback
 from banal import as_bool
 from normality import stringify
-from typing import List, Union, Any, Dict, Optional, Generator, Generic
+from typing import List, Set, Union, Any, Dict, Optional, Generator, Generic
 from abc import ABC, abstractmethod
 from requests import Session
 from requests.exceptions import RequestException, ChunkedEncodingError
@@ -37,7 +37,14 @@ class BaseEnricher(Generic[DS]):
         self.config = config
         self.cache_days = int(config.pop("cache_days", 90))
         self._filter_schemata = config.pop("schemata", [])
-        self._filter_topics = config.pop("topics", [])
+        filter_topics = set(config.pop("topics", []))
+        if "all" in filter_topics:
+            assert isinstance(registry.topic, TopicType)
+            filter_topics.discard("all")
+            filter_topics.update(registry.topic.names.keys())
+        # The resolved `topics` config option. Exposed so that callers gating
+        # further processing on the same topics use an identical set.
+        self.filter_topics: Set[str] = filter_topics
 
     def get_config_expand(
         self, name: str, default: Optional[str] = None
@@ -71,13 +78,9 @@ class BaseEnricher(Generic[DS]):
         if len(self._filter_schemata):
             if entity.schema.name not in self._filter_schemata:
                 return False
-        _filter_topics = set(self._filter_topics)
-        if "all" in _filter_topics:
-            assert isinstance(registry.topic, TopicType)
-            _filter_topics.update(registry.topic.names.keys())
-        if len(_filter_topics):
+        if len(self.filter_topics):
             topics = set(entity.get_type_values(registry.topic))
-            if not len(topics.intersection(_filter_topics)):
+            if not topics.intersection(self.filter_topics):
                 return False
         return True
 
@@ -222,6 +225,10 @@ class Enricher(BaseEnricher[DS], ABC):
         yield from self.match(entity)
 
     def expand_wrapped(self, entity: SE, match: SE) -> Generator[SE, None, None]:
+        """Yield the confirmed match itself, followed by entities related to
+        it in the external source (e.g. officers, owners, family members).
+
+        Only yields if ``entity`` passes the filter."""
         if not self._filter_entity(entity):
             return
         yield from self.expand(entity, match)

--- a/tests/enrich/test_common.py
+++ b/tests/enrich/test_common.py
@@ -1,0 +1,48 @@
+from followthemoney import Dataset, StatementEntity, registry
+
+from nomenklatura.enrich.common import BaseEnricher
+
+dataset = Dataset.make({"name": "test", "title": "Test"})
+
+
+def make_entity(schema: str, topics: list = []) -> StatementEntity:
+    properties = {"name": ["Thing"], "topics": topics}
+    data = {"schema": schema, "id": "xxx", "properties": properties}
+    return StatementEntity.from_data(dataset, data)
+
+
+def test_filter_topics_resolved(cache_factory):
+    cache = cache_factory(dataset)
+    enricher = BaseEnricher(dataset, cache, {"topics": ["sanction", "crime.boss"]})
+    assert enricher.filter_topics == {"sanction", "crime.boss"}
+
+    enricher = BaseEnricher(dataset, cache, {})
+    assert enricher.filter_topics == set()
+
+    # "all" expands to every topic and doesn't remain in the set as a literal.
+    enricher = BaseEnricher(dataset, cache, {"topics": ["all"]})
+    assert enricher.filter_topics == set(registry.topic.names.keys())
+
+
+def test_filter_entity_topics(cache_factory):
+    cache = cache_factory(dataset)
+    enricher = BaseEnricher(dataset, cache, {"topics": ["sanction"]})
+    assert enricher._filter_entity(make_entity("Person", ["sanction"]))
+    assert not enricher._filter_entity(make_entity("Person", ["crime.boss"]))
+    assert not enricher._filter_entity(make_entity("Person"))
+
+    # No topics configured: nothing is filtered on topic.
+    enricher = BaseEnricher(dataset, cache, {})
+    assert enricher._filter_entity(make_entity("Person"))
+
+    # "all" passes any tagged entity, but not untagged ones.
+    enricher = BaseEnricher(dataset, cache, {"topics": ["all"]})
+    assert enricher._filter_entity(make_entity("Person", ["crime.boss"]))
+    assert not enricher._filter_entity(make_entity("Person"))
+
+
+def test_filter_entity_schemata(cache_factory):
+    cache = cache_factory(dataset)
+    enricher = BaseEnricher(dataset, cache, {"schemata": ["Person"]})
+    assert enricher._filter_entity(make_entity("Person"))
+    assert not enricher._filter_entity(make_entity("Company"))


### PR DESCRIPTION
Resolve the `topics` config option (including "all" expansion) in BaseEnricher.__init__ and expose the result as `filter_topics`, so callers that gate further processing on the same topics — like zavod's topic-gated enrichment expansion — can consume the identical set instead of re-interpreting the raw config. _filter_entity now checks against the resolved set; behavior is unchanged.