### PR TITLE
Fix Wikipedia hosts for variant-language sitelinks

### DIFF
--- a/nomenklatura/wikidata/model.py
+++ b/nomenklatura/wikidata/model.py
@@ -118,7 +118,9 @@ class SiteLink(object):
         self.qid = qid
         self.site = data.pop("site")
         self.is_wiki = self.site.endswith("wiki")
-        self.wiki_site = self.site[:-4] if self.is_wiki else None
+        # Site codes use underscores where the wiki subdomain uses hyphens
+        # (zh_yuewiki -> zh-yue.wikipedia.org), so translate to the hostname form.
+        self.wiki_site = self.site[:-4].replace("_", "-") if self.is_wiki else None
         self.title = data.pop("title")
         self.badges = data.pop("badges", [])
         self.url = str(data.pop("url")) if "url" in data else None

--- a/nomenklatura/wikidata/wikipedia.py
+++ b/nomenklatura/wikidata/wikipedia.py
@@ -2,6 +2,7 @@ import logging
 from typing import Dict, List, Optional, Set
 from urllib.parse import quote
 from requests import Session
+from requests.exceptions import RequestException
 from rigour.langs import PREFERRED_LANGS
 from rigour.territories import get_territory
 from followthemoney import StatementEntity
@@ -31,9 +32,11 @@ def fetch_summary(
 
     Reach for this to give a reconciliation reviewer a one-glance "who is this"
     for a candidate Wikidata item. `lang` is the Wikipedia subdomain code (the
-    `en` of `enwiki`), `title` the page title. Returns None for a missing page
-    or one without an extract (e.g. a disambiguation page); both outcomes are
-    cached as an empty string so repeated runs don't re-request them.
+    `en` of `enwiki`), `title` the page title. Returns None for a missing page,
+    one without an extract (e.g. a disambiguation page), or any request failure
+    — callers never see an exception. Missing pages and empty extracts are
+    cached as an empty string so repeated runs don't re-request them; request
+    failures are not cached.
     """
     api_url = SUMMARY_API.format(
         lang=lang, title=quote(title.replace(" ", "_"), safe="")
@@ -41,12 +44,17 @@ def fetch_summary(
     cached = cache.get(api_url, max_age=SUMMARY_CACHE_DAYS)
     if cached is not None:
         return cached or None  # "" is the cached "no summary" sentinel
-    res = session.get(api_url)
-    if res.status_code == 404:
-        cache.set(api_url, "")
+    try:
+        res = session.get(api_url)
+        if res.status_code == 404:
+            cache.set(api_url, "")
+            return None
+        res.raise_for_status()
+        extract = res.json().get("extract") or ""
+    except RequestException as exc:
+        # Transient failures are not cached, so the next run retries them.
+        log.warning("Failed to fetch summary %s: %s", api_url, exc)
         return None
-    res.raise_for_status()
-    extract = res.json().get("extract") or ""
     cache.set(api_url, extract)
     return extract or None
 
@@ -96,7 +104,13 @@ def item_wikipedia_summaries(
     by_lang: Dict[str, str] = {}
     titles: Dict[str, str] = {}
     for link in item.wikilinks:
-        if link.lang is None or link.wiki_site is None or link.lang in by_lang:
+        if link.lang is None or link.wiki_site is None:
+            continue
+        # Variant wikis (zh-yue, zh-classical, be-x-old) resolve to the same
+        # language code as the plain wiki; prefer the plain one (zh, be)
+        # regardless of sitelink order.
+        current = by_lang.get(link.lang)
+        if current is not None and ("-" not in current or "-" in link.wiki_site):
             continue
         by_lang[link.lang] = link.wiki_site
         titles[link.lang] = link.title

--- a/tests/test_wikipedia.py
+++ b/tests/test_wikipedia.py
@@ -1,4 +1,5 @@
 import re
+import requests
 import requests_mock
 from followthemoney import Dataset
 from followthemoney import StatementEntity as Entity
@@ -52,6 +53,43 @@ def test_fetch_summary_negative_cache(cache_factory) -> None:
         assert fetch_summary(cache, session, "en", "Nobody") is None
     # A second call is served from the empty-string sentinel, no HTTP needed.
     assert fetch_summary(cache, session, "en", "Nobody") is None
+
+
+def test_fetch_summary_errors_swallowed_not_cached(cache_factory) -> None:
+    cache = cache_factory(Dataset.make({"name": "wikidata"}))
+    session = make_session()
+    with requests_mock.Mocker(real_http=False) as m:
+        m.register_uri("GET", SUMMARY_URL, exc=requests.exceptions.ConnectionError)
+        assert fetch_summary(cache, session, "en", "Flaky") is None
+    with requests_mock.Mocker(real_http=False) as m:
+        m.register_uri("GET", SUMMARY_URL, status_code=503)
+        assert fetch_summary(cache, session, "en", "Flaky") is None
+    # The failures left no cache entry: a working endpoint is queried again.
+    with requests_mock.Mocker(real_http=False) as m:
+        m.register_uri("GET", SUMMARY_URL, json={"extract": "A person."})
+        assert fetch_summary(cache, session, "en", "Flaky") == "A person."
+
+
+def test_sitelink_underscore_site_builds_hyphen_host() -> None:
+    item = _item("zh_yuewiki")
+    (link,) = item.wikilinks
+    assert link.wiki_site == "zh-yue"
+    assert link.lang == "zho"
+
+
+def test_item_summaries_variant_wiki_host_and_shadowing(cache_factory) -> None:
+    cache = cache_factory(Dataset.make({"name": "wikidata"}))
+    session = make_session()
+    # The variant wikis sort before the plain one in the API response, but the
+    # plain-language wiki must win for the shared language code.
+    item = _item("zh_classicalwiki", "zh_yuewiki", "zhwiki", "be_x_oldwiki")
+    with requests_mock.Mocker(real_http=False) as m:
+        m.register_uri("GET", SUMMARY_URL, json={"extract": "A person."})
+        summaries = item_wikipedia_summaries(cache, session, item, ["zho", "bel"])
+        assert {s.lang for s in summaries} == {"zho", "bel"}
+        hosts = {r.hostname for r in m.request_history}
+        # zhwiki beats the variants; be-x-old (no plain bewiki) gets a valid host.
+        assert hosts == {"zh.wikipedia.org", "be-x-old.wikipedia.org"}
 
 
 def test_item_summaries_preferred_only_and_capped(cache_factory) -> None:


### PR DESCRIPTION
Wikidata site codes use underscores where the actual Wikipedia subdomain uses hyphens (`zh_yuewiki` → `zh-yue.wikipedia.org`), but `SiteLink` passed the raw code into the summary API URL. This was masked while `iso_639_alpha3` returned `None` for variant codes — those sitelinks were simply skipped. Since rigour started resolving BCP 47-style tags via their primary subtag, variant sitelinks participate in summary fetching and produced unresolvable hosts like `zh_yue.wikipedia.org`, crashing xref runs downstream.

Changes:

- `SiteLink.wiki_site` translates the site code to hostname form (underscore → hyphen), so variant wikis get valid hosts.
- `item_wikipedia_summaries` prefers the plain-language wiki (`zhwiki`) over variant wikis (`zh_yuewiki`, `zh_classicalwiki`) that resolve to the same language code, instead of letting alphabetical sitelink order decide. Variants are still used when no plain edition is linked.
- `fetch_summary` catches all request-level errors (connection failures, non-404 HTTP errors, malformed JSON) and returns `None` instead of raising, so `Optional[str]` is the whole downstream contract. Failures are logged and not cached, so later runs retry them; the 404 / empty-extract negative cache is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)