### PR TITLE
logic_v2: don't literal-match names with contradicting part tags

### DIFF
--- a/nomenklatura/matching/logic_v2/names/match.py
+++ b/nomenklatura/matching/logic_v2/names/match.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 from rigour.names import Alignment, CompareConfig, NameTypeTag, Name, NamePart
 from rigour.names import align_person_name_order, compare_parts, normalize_name
 from rigour.names import remove_obj_prefixes
@@ -20,6 +20,7 @@ from nomenklatura.matching.logic_v2.names.util import (
     explain_alignment,
     is_family_name,
     numbers_mismatch,
+    part_tags_compatible,
 )
 from nomenklatura.matching.types import FtResult, ScoringConfig
 from nomenklatura.matching.util import FNUL
@@ -182,21 +183,28 @@ def name_match(query: E, result: E, config: ScoringConfig) -> FtResult:
 
     # For literal matches, return early instead of performing all the magic. This addresses
     # a user surprise where literal matches can score below 1.0 after name de-duplication has
-    # only left a superset name on one side.
-    query_comparable = {name.comparable: name for name in query_names}
-    result_comparable = {name.comparable: name for name in result_names}
+    # only left a superset name on one side. Names whose part tags contradict each other
+    # (e.g. a reversed firstName/lastName query against a "Family, Given"-form alias) don't
+    # qualify — they fall through to the full machinery, which penalises the role swap.
+    query_comparable: Dict[str, List[Name]] = {}
+    for name in query_names:
+        query_comparable.setdefault(name.comparable, []).append(name)
+    result_comparable: Dict[str, List[Name]] = {}
+    for name in result_names:
+        result_comparable.setdefault(name.comparable, []).append(name)
     common = set(query_comparable).intersection(result_comparable)
-    if len(common) > 0:
-        longest = max(common, key=len)
-        q_name = query_comparable[longest]
-        r_name = result_comparable[longest]
-        align = Alignment(qps=q_name.parts, rps=r_name.parts, score=1.0)
-        return FtResult(
-            score=1.0,
-            detail=explain_alignment(align),
-            query=q_name.original,
-            candidate=r_name.original,
-        )
+    for comparable in sorted(common, key=len, reverse=True):
+        for q_name in query_comparable[comparable]:
+            for r_name in result_comparable[comparable]:
+                if not part_tags_compatible(q_name, r_name):
+                    continue
+                align = Alignment(qps=q_name.parts, rps=r_name.parts, score=1.0)
+                return FtResult(
+                    score=1.0,
+                    detail=explain_alignment(align),
+                    query=q_name.original,
+                    candidate=r_name.original,
+                )
 
     # Remove short names that are contained in longer names.
     # This prevents a scenario where a short version of a name ("John

--- a/nomenklatura/matching/logic_v2/names/util.py
+++ b/nomenklatura/matching/logic_v2/names/util.py
@@ -1,6 +1,21 @@
 import re
 
-from rigour.names import Alignment, NamePartTag
+from rigour.names import Alignment, Name, NamePartTag
+
+
+def part_tags_compatible(query: Name, result: Name) -> bool:
+    """Check two comparable-equal names for contradicting part roles.
+
+    Guards the literal-match early exit: a query with firstName=Putin,
+    lastName=Vladimir produces the same comparable string as a
+    "PUTIN, Vladimir"-style alias on the result, but matches the family
+    name against the given name. Such pairs must fall through to the
+    full alignment machinery, which penalises the role swap, instead of
+    short-circuiting to a 1.0 literal match."""
+    for qp, rp in zip(query.parts, result.parts):
+        if not qp.tag.can_match(rp.tag):
+            return False
+    return True
 
 
 def is_family_name(alignment: Alignment) -> bool:

--- a/tests/matching/logic_v2/names/test_match.py
+++ b/tests/matching/logic_v2/names/test_match.py
@@ -15,6 +15,42 @@ def test_name_match():
     assert res.candidate == "Smith, John"
 
 
+def test_name_match_reversed_part_tags():
+    # https://github.com/opensanctions/nomenklatura/issues/247 — a query with
+    # firstName/lastName swapped produces the same comparable string as a
+    # "Family, Given"-form alias on the result. That must not short-circuit
+    # to a 1.0 literal match: the part tags contradict each other.
+    result = e(
+        "Person",
+        name=["Vladimir Putin", "PUTIN, Vladimir"],
+        firstName="Vladimir",
+        lastName="Putin",
+    )
+    reversed_query = e(
+        "Person",
+        name="putin vladimir",
+        firstName="putin",
+        lastName="vladimir",
+    )
+    res = name_match(reversed_query, result, config)
+    assert res.score < 0.7, res
+
+    correct_query = e(
+        "Person",
+        name="vladimir putin",
+        firstName="vladimir",
+        lastName="putin",
+    )
+    res = name_match(correct_query, result, config)
+    assert res.score == 1.0, res
+
+    # An untagged result name in reversed order stays a literal match: its
+    # UNSET parts haven't committed to a role, so nothing contradicts.
+    untagged_result = e("Person", name="putin vladimir")
+    res = name_match(reversed_query, untagged_result, config)
+    assert res.score == 1.0, res
+
+
 # def test_specific():
 #     left = e("Company", name="N.A.B.C Company")
 #     right = e("Company", name="A.B.C. Company")


### PR DESCRIPTION
Closes #247.

## Problem

The literal-match early exit in `name_match` compares whitespace-normalized `comparable` strings only. A structured query with firstName/lastName swapped (`firstName=putin, lastName=vladimir` — which yente's `combine_names` turns into the alias `putin vladimir`) therefore scored a **1.0 literalMatch** against any "Family, Given"-form alias on the result (`PUTIN, Vladimir` → `putin vladimir`), even though the query's GIVEN part is being matched against the result's FAMILY part.

The machinery behind the early exit already handles this correctly: `NamePartTag.can_match` is enforced in symbol pairing and in `align_person_name_order`, so GIVEN↔FAMILY pairings are refused there. The early exit just bypassed all of it.

## Fix

Gate the early exit on `NamePartTag.can_match` per position (comparable equality guarantees identical token sequences, so parts are zipped pairwise). Contradicting pairs fall through to the full scorer.

- Reversed Putin query vs. the Q7747 entity from the issue: **1.0 → 0.51**, with the explanation showing `putin` unmatched on both sides:
  `['vladimir' literalMatch: 1.00, weight 1.30] ['putin' extraQueryPart: 0.00, weight 0.80] ...`
- Correct-order query: stays **1.0**.
- Untagged names are unaffected (`UNSET` is a `can_match` wildcard): `John Smith` vs `Smith, John` still literal-matches at 1.0.

The comparable→name lookups become dicts of lists so that when several names share a comparable form, a tag-compatible pairing is still found rather than depending on which name the dict kept last; iteration remains longest-comparable-first.

Note this is a demotion, not a rejection — the reversed pair still earns a mid-range score from the genuinely shared given name. The second half of #247 (whether tagged↔UNSET matches like `PEREZ FERNANDO` should be mildly downweighted) is deliberately not touched: per the discussion on the issue, that match was in fact correct (uy_pep stores names family-name-first), and any penalty is a tuning decision that needs benchmark evidence — worth a fresh issue if it resurfaces in practice.

## Testing

- New regression test `test_name_match_reversed_part_tags` covering all three behaviours above.
- Full `tests/matching` suite passes (189 tests); `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
