### PR TITLE
Add part-pair blocking tokens

### DIFF
--- a/nomenklatura/blocker/index.py
+++ b/nomenklatura/blocker/index.py
@@ -44,6 +44,7 @@ from nomenklatura.resolver import Identifier
 from nomenklatura.store import View
 from nomenklatura.blocker.tokenizer import (
     NAME_PART_FIELD,
+    PART_PAIR_FIELD,
     WORD_FIELD,
     tokenize_entity,
 )
@@ -83,6 +84,7 @@ class Index(object):
 
     BOOSTS = {
         NAME_PART_FIELD: 5.0,
+        PART_PAIR_FIELD: 7.0,
         WORD_FIELD: 0.5,
         registry.name.name: 15.0,
         registry.phone.name: 10.0,

--- a/nomenklatura/blocker/tokenizer.py
+++ b/nomenklatura/blocker/tokenizer.py
@@ -1,3 +1,4 @@
+from itertools import combinations
 from normality import WS
 from rigour.ids import StrictFormat
 from rigour.addresses import normalize_address
@@ -10,7 +11,10 @@ from followthemoney.names import entity_names
 
 WORD_FIELD = "wd"
 NAME_PART_FIELD = "np"
+PART_PAIR_FIELD = "pp"
 SYMBOL_FIELD = "sy"
+# Cap the O(k²) growth of part-pair tokens for many-part (mostly org) names:
+MAX_PAIR_PARTS = 6
 SKIP = (
     # done via entity_names:
     registry.name,
@@ -83,6 +87,23 @@ def tokenize_entity(entity: StatementEntity) -> Generator[Tuple[str, str], None,
             if len(part.comparable) < 3 or len(part.comparable) > 30:
                 continue
             unique.add((NAME_PART_FIELD, f"{NAME_PART_FIELD}:{part.comparable}"))
+
+        # Part pairs: within-name co-occurrence of two parts. Buckets are far
+        # smaller than single-part buckets, so these survive stopwording for
+        # common names ("John Smith" ~ "John Q. Smith" share pp:john smith).
+        pairable = sorted(
+            {
+                part.comparable
+                for part in name.parts
+                if part.tag not in (NamePartTag.STOP, NamePartTag.LEGAL)
+                and 2 <= len(part.comparable) <= 30
+            }
+        )
+        if len(pairable) > MAX_PAIR_PARTS:
+            # keep the longest parts as the most distinctive ones
+            pairable = sorted(sorted(pairable, key=len, reverse=True)[:MAX_PAIR_PARTS])
+        for lpart, rpart in combinations(pairable, 2):
+            unique.add((PART_PAIR_FIELD, f"{PART_PAIR_FIELD}:{lpart}{WS}{rpart}"))
 
         if name.comparable:
             name_fp = "".join(sorted({part.comparable for part in name.parts}))

--- a/tests/blocker/test_index.py
+++ b/tests/blocker/test_index.py
@@ -87,6 +87,35 @@ def test_max_bucket_size_rejects_negative_values(
         raise AssertionError("expected max_bucket_size to reject negative values")
 
 
+def test_tokenize_part_pairs(test_dataset: Dataset):
+    def name_entity(schema: str, name: str) -> StatementEntity:
+        data = {"id": name, "schema": schema, "properties": {"name": [name]}}
+        return StatementEntity.from_data(test_dataset, data)
+
+    def pp_tokens(schema: str, name: str) -> set[str]:
+        tokens = set(tokenize_entity(name_entity(schema, name)))
+        return {token for field, token in tokens if field == "pp"}
+
+    # a shared pair survives a divergent middle name
+    assert "pp:john smith" in pp_tokens("Person", "John Smith")
+    assert "pp:john smith" in pp_tokens("Person", "John Quincy Smith")
+
+    # short parts under the np length floor still pair up
+    assert pp_tokens("Person", "Li Yu") == {"pp:li yu"}
+
+    # legal-form parts are excluded, so org-type variants share pairs
+    assert pp_tokens("Company", "Acme Holdings LLC") == pp_tokens(
+        "Company", "Acme Holdings GmbH"
+    )
+
+    # mononyms emit no pairs
+    assert pp_tokens("Person", "Prince") == set()
+
+    # many-part names are capped at MAX_PAIR_PARTS parts
+    long_name = "Alpha Bravo Charlie Delta Echo Foxtrot Golf Hotel"
+    assert len(pp_tokens("Company", long_name)) == 15
+
+
 def test_index_build(index_path: Path, dstore: SimpleMemoryStore):
     index = Index(dstore.default_view(), index_path)
     assert index.entity_count("entries") == 0


### PR DESCRIPTION
Builds on the tokenizer fixes from #345.

Emits within-name part 2-combinations as a new `pp` blocking token field (boost 7.0): the sorted, deduplicated non-STOP/LEGAL parts of each name, capped at the 6 longest parts (≤15 pairs per name).

## Why

Dynamic cost-based stopwords remove exactly the tokens common names are made of: on the 2023 consolidated sanctions corpus, **28.2% of `np` (single name part) rows are stopworded** at the default bucket cap. Pair buckets are structurally smaller — `df(pair) ≤ min(df(part))` — so only **1.6% of `pp` rows** get stopworded, and pairs stay alive deep into the common-name band. Unlike the full-name fingerprint, pairs are robust to an extra or missing part:

- `John Smith` ↔ `John Quincy Smith` share `pp:john smith`
- `Acme Holdings LLC` ↔ `Acme Holdings GmbH` share `pp:acme holdings` (legal forms excluded)
- `Li Yu` gets a lexical token (`pp:li yu`) despite both parts falling under the 3-char `np` floor

The full-name fingerprint stays: it remains the last resort for names whose every pair is also common (fleet vessels, research institutes), effectively-mononym orgs ("OJSC Gazprom"), and the exact-name ranking signal.

## Cost

`pp` roughly doubles name-derived index rows (+357k on 360k `np`+fingerprint rows on the measurement corpus). Production-scale row growth/peak RSS still needs the blocker-spec scale test; see the labelled-pair ablation results in the comments for measured recall contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
