### PR TITLE
Insert statements via executemany instead of an inline VALUES clause

### DIFF
--- a/nomenklatura/db.py
+++ b/nomenklatura/db.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Generator, Iterable, List, Mapping, Optional, cast
 import logging
 
 from followthemoney import Statement
-from followthemoney.statement.util import get_prop_type
 from sqlalchemy import (
     Boolean,
     Column,
@@ -85,6 +84,19 @@ def is_sqlite(dialect: Dialect) -> bool:
     return dialect.name == "sqlite"
 
 
+def dialect_insert(dialect: Dialect, table: Table) -> PostgreSQLInsert | SQLiteInsert:
+    """Build an insert that supports the given database's upsert API.
+
+    Use this instead of `sqlalchemy.insert` wherever an `on_conflict_*` clause is
+    needed, since those are dialect extensions rather than part of core SQL.
+    """
+    if is_sqlite(dialect):
+        return sqlite_insert(table)
+    if is_postgres(dialect):
+        return psql_insert(table)
+    raise NotImplementedError(f"Upsert not implemented for dialect {dialect.name}")
+
+
 class Session:
     """Own a single database connection for one unit of work.
 
@@ -119,13 +131,7 @@ class Session:
 
     def insert(self, table: Table) -> PostgreSQLInsert | SQLiteInsert:
         """Build an insert that supports the active database's upsert API."""
-        if self.is_sqlite:
-            return sqlite_insert(table)
-        if self.is_postgres:
-            return psql_insert(table)
-        raise NotImplementedError(
-            f"Upsert not implemented for dialect {self.dialect.name}"
-        )
+        return dialect_insert(self.dialect, table)
 
     def create(self, *tables: Table) -> None:
         """Create the given tables on this session's connection."""
@@ -208,22 +214,6 @@ def make_statement_table(
     )
 
 
-def _upsert_statement_batch(
-    dialect: Dialect, conn: Connection, table: Table, batch: List[Mapping[str, Any]]
-) -> None:
-    """Create an upsert statement for the given table and engine."""
-    if is_sqlite(dialect):
-        lstmt = sqlite_insert(table).values(batch)
-        lstmt = lstmt.on_conflict_do_nothing(index_elements=["id"])
-        conn.execute(lstmt)
-    elif is_postgres(dialect):
-        pstmt = psql_insert(table).values(batch)
-        pstmt = pstmt.on_conflict_do_nothing(index_elements=["id"])
-        conn.execute(pstmt)
-    else:
-        raise NotImplementedError(f"Upsert not implemented for dialect {dialect.name}")
-
-
 def insert_statements(
     engine: Engine,
     table: Table,
@@ -233,7 +223,17 @@ def insert_statements(
 ) -> None:
     dataset_count: int = 0
     is_postgresql = is_postgres(engine.dialect)
+    # Built once and re-used for every batch: rows are passed as executemany
+    # parameters, so SQLAlchemy compiles the statement only on the first batch.
+    # An inline `.values(batch)` clause instead makes each batch a distinct
+    # statement, and compiling one costs more than parsing the statements did.
+    upsert = dialect_insert(engine.dialect, table).on_conflict_do_nothing(
+        index_elements=["id"]
+    )
     if not is_postgresql:
+        # Bound the parameters per statement, in case the dialect rewrites the
+        # executemany into a single multi-row INSERT (as psycopg2 does), which
+        # would otherwise exceed SQLITE_MAX_VARIABLE_NUMBER.
         sqlite_max_batch = SQLITE_MAX_VARS // len(table.columns)
         batch_size = min(batch_size, sqlite_max_batch)
     with engine.begin() as conn:
@@ -243,8 +243,12 @@ def insert_statements(
 
         for stmt in statements:
             if is_postgresql:
+                # Not to_db_row(): that yields UTC-aware datetimes, which psycopg2
+                # sends as timestamptz, and casting those into the naive timestamp
+                # columns shifts them by the session TimeZone. The ISO strings are
+                # cast literally instead, so a load does not depend on the setting.
                 row = cast(Dict[str, Any], stmt.to_dict())
-                row["prop_type"] = get_prop_type(row["schema"], row["prop"])
+                row["prop_type"] = stmt.prop_type
             else:
                 row = stmt.to_db_row()
             batch.append(row)
@@ -252,10 +256,10 @@ def insert_statements(
             if len(batch) >= batch_size:
                 args = (len(batch), dataset_count, dataset_name)
                 log.info("Inserting batch %s statements (total: %s) into %r" % args)
-                _upsert_statement_batch(engine.dialect, conn, table, batch)
+                conn.execute(upsert, batch)
                 batch = []
         if len(batch):
-            _upsert_statement_batch(engine.dialect, conn, table, batch)
+            conn.execute(upsert, batch)
         log.info("Load complete: %r (%d total)" % (dataset_name, dataset_count))
 
 


### PR DESCRIPTION
`insert_statements` built `insert(table).values(batch)` for every batch, which makes each batch a distinct statement that SQLAlchemy has to compile from scratch. That compile is the bottleneck of the whole loader:

| | |
|---|---|
| compile `INSERT..VALUES(1500 rows)` | 88.6 ms/batch (~17k stmt/s ceiling) |
| compile parameterised `INSERT` | 0.043 ms, and cacheable |
| parse + canonicalise statements | ~400k stmt/s |

So the client spent more time assembling SQL than reading and resolving the statements it was inserting.

This builds the upsert once and passes the rows as executemany parameters. Measured on 200k statements into a fully-indexed statement table:

| dialect | before | after | |
|---|---|---|---|
| PostgreSQL 17 (local socket) | 9,811 stmt/s | **15,185 stmt/s** | 1.55x |
| SQLite | 12,615 stmt/s | **95,290 stmt/s** | 7.6x |

Batch size is now nearly irrelevant to throughput, where before it barely helped because the compile cost scaled with it.

### Duplicate handling is unchanged

psycopg2 has `use_insertmanyvalues_wo_returning = True`, so executemany is paged into multi-row `VALUES` groups where `ON CONFLICT DO NOTHING` still resolves per row; pysqlite does a plain row-by-row `cursor.executemany`. Verified both ways by feeding the loader a statement that collides with an earlier one on `id` but carries a later `first_seen`: 200,000 rows land and the surviving row keeps the **first** occurrence's `first_seen`, matching the previous behaviour exactly.

The SQLite batch clamp stays. It is no longer needed for pysqlite's row-by-row path, but still guards the case where a dialect rewrites executemany into a single multi-row INSERT, and its comment now says so.

### Also in here

- Dialect dispatch moves to a module-level `dialect_insert()`, shared with `Session.insert`, which drops a duplicated `NotImplementedError` branch. An unsupported dialect now raises *before* the DELETE instead of on the first batch.
- `row["prop_type"] = stmt.prop_type` rather than calling `get_prop_type(schema, prop)` again — `Statement.__init__` already computed it from the same call.
- A comment recording why the PostgreSQL branch cannot use `to_db_row()`: it returns UTC-aware datetimes, psycopg2 sends those as `timestamptz`, and casting into the naive `timestamp` columns shifts them by the session TimeZone. Same row, same table, only the session setting differing:

  ```
  TimeZone=UTC            to_dict -> 2024-01-01 00:00:00 | to_db_row -> 2024-01-01 00:00:00
  TimeZone=Europe/Berlin  to_dict -> 2024-01-01 00:00:00 | to_db_row -> 2024-01-01 01:00:00
  ```

  Cloud SQL defaults to UTC, so that difference would be invisible in production and wrong on a developer machine. Making the columns `DateTime(timezone=True)` is the real fix, but that needs a migration and belongs on its own.

### Testing

`mypy --strict` clean, `ruff format --check` clean, 316 tests pass — including `test_insert_statements_sqlite_large_batch`, which exercises the clamp. The zavod suite (287 tests) also passes against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)