### PR TITLE
Blocker: rank candidates by rarity-weighted evidence, fix alias dilution

### DIFF
--- a/nomenklatura/blocker/index.py
+++ b/nomenklatura/blocker/index.py
@@ -74,15 +74,10 @@ def batched(iterable: Iterable[R], n: int) -> Generator[Tuple[R, ...], None, Non
 
 
 class Index(object):
-    """
-    An index using DuckDB for token matching and scoring, keeping data in memory
-    until it needs to spill to disk as it approaches the configured memory limit.
+    """Rank token-overlapping entity candidates with a DuckDB index.
 
-    Pairs match if they share one or more tokens. The similarity score weighs each
-    shared token by its rarity across the indexed entities (IDF) and its field's
-    boost, dampens tokens that merely multiply with an entity's alias count, and
-    grants extra same-field tokens only logarithmic credit — so that distinctive
-    shared evidence outranks pairs that share many correlated or common tokens.
+    Use this to generate dedupe pairs or match incoming entities when exhaustive
+    comparison is impractical.
     """
 
     BOOSTS = {
@@ -497,16 +492,9 @@ class Index(object):
 
     def _build_frequencies(self) -> None:
         log.info("Calculating term weights...")
-        # A token's weight is presence-based: matching one of an entity's names
-        # must not be discounted because the entity has other aliases, so there
-        # is no normalisation by field length. Rarity across the indexed
-        # entities (IDF) is what separates distinctive evidence from
-        # common-token noise. Name-part and symbol tokens multiply with an
-        # entity's alias count without adding independent evidence, so they
-        # are dampened by the square root of the entity's name count — a no-op
-        # for single-name entities. This assumes aliases contribute distinct
-        # parts; near-duplicate aliases (transliterations sharing most parts)
-        # are over-dampened by up to that same square root.
+        # IDF separates distinctive evidence from common-token noise without
+        # letting aliases dilute full-name matches. Dampen alias-derived parts
+        # and symbols because they multiply with the number of names.
         term_frequencies_query = f"""
         CREATE OR REPLACE TABLE term_frequencies_all AS
             WITH entity_count AS (
@@ -597,10 +585,7 @@ class Index(object):
         self._ensure_pair_stopwords()
         self._log_pair_query_stats(max_pairs)
         log.info("Generating pairs...")
-        # Within one field, extra shared tokens are mostly correlated evidence
-        # (translations and variants of the same name), so per field the best
-        # shared token counts in full and each additional one earns only
-        # logarithmic credit. Distinct fields are independent evidence and sum.
+        # Limit correlated evidence with logarithmic credit per field.
         pairs_query = """
             SELECT lid, rid, sum(maxw * (1.0 + ln(n))) AS score
             FROM (
@@ -701,8 +686,7 @@ class Index(object):
 
         log.info("Matching %d entities in %d chunks...", num_matching, chunks)
         for chunk in range(1, chunks + 1):
-            # Same per-field correlated-evidence damper as in pairs(): best
-            # shared token in full, log credit for the rest, fields sum.
+            # Apply the same per-field aggregation used by pairs().
             chunk_query = """
             SELECT matching_id, matches_id, sum(maxw * (1.0 + ln(n))) AS score
                 FROM (

--- a/nomenklatura/blocker/index.py
+++ b/nomenklatura/blocker/index.py
@@ -44,6 +44,7 @@ from nomenklatura.resolver import Identifier
 from nomenklatura.store import View
 from nomenklatura.blocker.tokenizer import (
     NAME_PART_FIELD,
+    SYMBOL_FIELD,
     WORD_FIELD,
     tokenize_entity,
 )
@@ -77,8 +78,11 @@ class Index(object):
     An index using DuckDB for token matching and scoring, keeping data in memory
     until it needs to spill to disk as it approaches the configured memory limit.
 
-    Pairs match if they share one or more tokens. A basic similarity score is calculated
-    cumulatively based on each token's Term Frequency (TF) and the field's boost factor.
+    Pairs match if they share one or more tokens. The similarity score weighs each
+    shared token by its rarity across the indexed entities (IDF) and its field's
+    boost, dampens tokens that merely multiply with an entity's alias count, and
+    grants extra same-field tokens only logarithmic credit — so that distinctive
+    shared evidence outranks pairs that share many correlated or common tokens.
     """
 
     BOOSTS = {
@@ -492,18 +496,41 @@ class Index(object):
         )
 
     def _build_frequencies(self) -> None:
-        log.info("Calculating term frequencies...")
-        term_frequencies_query = """
+        log.info("Calculating term weights...")
+        # A token's weight is presence-based: matching one of an entity's names
+        # must not be discounted because the entity has other aliases, so there
+        # is no normalisation by field length. Rarity across the indexed
+        # entities (IDF) is what separates distinctive evidence from
+        # common-token noise. Name-part and symbol tokens multiply with an
+        # entity's alias count without adding independent evidence, so they
+        # are dampened by the square root of the entity's name count — a no-op
+        # for single-name entities.
+        term_frequencies_query = f"""
         CREATE OR REPLACE TABLE term_frequencies_all AS
-            WITH field_len AS (
-                SELECT e.field, e.id, sum(e.count) as len
-                    FROM entries e
-                    GROUP BY e.field, e.id
+            WITH entity_count AS (
+                SELECT count(DISTINCT id) AS n FROM entries
+            ),
+            token_idf AS (
+                SELECT e.token, 1.0 + ln(c.n / count(DISTINCT e.id)) AS idf
+                FROM entries AS e, entity_count AS c
+                GROUP BY e.token, c.n
+            ),
+            name_counts AS (
+                SELECT id, greatest(1, sum(count)) AS n_names
+                FROM entries
+                WHERE field = '{registry.name.name}'
+                GROUP BY id
             )
-            SELECT e.schema, e.field, e.token, e.id, (e.count/f.len) * ifnull(boo.boost, 1) as tf
+            SELECT e.schema, e.field, e.token, e.id,
+                CASE WHEN e.field IN ('{NAME_PART_FIELD}', '{SYMBOL_FIELD}')
+                    THEN ifnull(boo.boost, 1) * i.idf
+                        / sqrt(ifnull(nc.n_names, 1))
+                    ELSE ifnull(boo.boost, 1) * i.idf
+                END AS weight
             FROM entries AS e
-            JOIN field_len AS f ON f.field = e.field AND f.id = e.id
-            LEFT OUTER JOIN boosts boo ON f.field = boo.field
+            JOIN token_idf AS i ON i.token = e.token
+            LEFT OUTER JOIN name_counts AS nc ON nc.id = e.id
+            LEFT OUTER JOIN boosts boo ON e.field = boo.field
         """
         self.con.execute(term_frequencies_query)
 
@@ -568,14 +595,24 @@ class Index(object):
         self._ensure_pair_stopwords()
         self._log_pair_query_stats(max_pairs)
         log.info("Generating pairs...")
+        # Within one field, extra shared tokens are mostly correlated evidence
+        # (translations and variants of the same name), so per field the best
+        # shared token counts in full and each additional one earns only
+        # logarithmic credit. Distinct fields are independent evidence and sum.
         pairs_query = """
-            SELECT "left".id, "right".id, sum(("left".tf + "right".tf)) as score
-            FROM term_frequencies as "left"
-            JOIN term_frequencies as "right" ON "left".token = "right".token
-            INNER JOIN schemata ON schemata.left = "left".schema AND schemata.right = "right".schema
-            WHERE "left".id > "right".id
-            GROUP BY "left".id, "right".id
-            ORDER BY score DESC
+            SELECT lid, rid, sum(maxw * (1.0 + ln(n))) AS score
+            FROM (
+                SELECT "left".id AS lid, "right".id AS rid, "left".field AS field,
+                    max("left".weight + "right".weight) AS maxw, count(*) AS n
+                FROM term_frequencies as "left"
+                JOIN term_frequencies as "right"
+                    ON "left".token = "right".token AND "left".field = "right".field
+                INNER JOIN schemata ON schemata.left = "left".schema AND schemata.right = "right".schema
+                WHERE "left".id > "right".id
+                GROUP BY "left".id, "right".id, "left".field
+            )
+            GROUP BY lid, rid
+            ORDER BY score DESC, lid, rid
             LIMIT ?
         """
         started = perf_counter()
@@ -662,17 +699,24 @@ class Index(object):
 
         log.info("Matching %d entities in %d chunks...", num_matching, chunks)
         for chunk in range(1, chunks + 1):
+            # Same per-field correlated-evidence damper as in pairs(): best
+            # shared token in full, log credit for the rest, fields sum.
             chunk_query = """
-            SELECT m.id AS matching_id, tf.id AS matches_id, SUM(tf.tf) AS score
-                FROM matching_chunks c
-                JOIN matching_filtered m ON c.id = m.id
-                JOIN term_frequencies_all tf
-                ON m.token = tf.token
-                INNER JOIN schemata s
-                ON s.left = m.schema AND s.right = tf.schema
-                WHERE c.chunk = ?
-                GROUP BY m.id, tf.id
-                ORDER BY m.id, score DESC
+            SELECT matching_id, matches_id, sum(maxw * (1.0 + ln(n))) AS score
+                FROM (
+                    SELECT m.id AS matching_id, tf.id AS matches_id, tf.field AS field,
+                        max(tf.weight) AS maxw, count(*) AS n
+                    FROM matching_chunks c
+                    JOIN matching_filtered m ON c.id = m.id
+                    JOIN term_frequencies_all tf
+                    ON m.token = tf.token AND m.field = tf.field
+                    INNER JOIN schemata s
+                    ON s.left = m.schema AND s.right = tf.schema
+                    WHERE c.chunk = ?
+                    GROUP BY m.id, tf.id, tf.field
+                )
+                GROUP BY matching_id, matches_id
+                ORDER BY matching_id, score DESC, matches_id
             """
             started = perf_counter()
             chunk_input_query = """

--- a/nomenklatura/blocker/index.py
+++ b/nomenklatura/blocker/index.py
@@ -504,7 +504,9 @@ class Index(object):
         # common-token noise. Name-part and symbol tokens multiply with an
         # entity's alias count without adding independent evidence, so they
         # are dampened by the square root of the entity's name count — a no-op
-        # for single-name entities.
+        # for single-name entities. This assumes aliases contribute distinct
+        # parts; near-duplicate aliases (transliterations sharing most parts)
+        # are over-dampened by up to that same square root.
         term_frequencies_query = f"""
         CREATE OR REPLACE TABLE term_frequencies_all AS
             WITH entity_count AS (

--- a/tests/blocker/test_index.py
+++ b/tests/blocker/test_index.py
@@ -524,9 +524,18 @@ def test_pairs_rank_distinctive_match_above_common_token_noise(
     linker = Linker({})
     store = SimpleMemoryStore(test_dataset, linker)
     writer = store.writer()
-    names = ["Journal Atlas Publishing House"] + [
-        f"Journal Atlas Publishing House ({i})" for i in range(num_names - 1)
-    ]
+    # transliterations and different-script variants: distinct fingerprints
+    # AND distinct name parts, so both name-field and np-field dilution under
+    # a length-normalising formula are exercised
+    names = [
+        "Journal Atlas Publishing House",
+        "Journal Atlas Publishing House Ltd",
+        "Zhurnal Atlas Pablishing Khaus",
+        "Журнал Атлас Паблишинг Хаус",
+        "Izdatelstvo Atlas",
+        "Издательство Атлас",
+        "Atlas Journal Verlag",
+    ][:num_names]
     writer.add_entity(
         StatementEntity.from_data(
             test_dataset,
@@ -564,6 +573,9 @@ def test_pairs_rank_distinctive_match_above_common_token_noise(
     try:
         index.build()
         pairs = list(index.pairs(max_pairs=2000))
+        # vacuity guard: the decoy pairs must actually be present -- above the
+        # stopword crossover they vanish and rank 0 would win by default
+        assert len(pairs) == 50 * 49 // 2 + 1, len(pairs)
         genuine = (Identifier.get("journal-atlas"), Identifier.get("fsf-atlas"))
         assert pairs[0][0] in (genuine, tuple(reversed(genuine))), pairs[0]
         # a strict win, not a tie broken by luck

--- a/tests/blocker/test_index.py
+++ b/tests/blocker/test_index.py
@@ -518,15 +518,11 @@ def test_matching_stopwords_count_oriented_schema_pairs_once(
 def test_pairs_rank_distinctive_match_above_common_token_noise(
     index_path: Path, test_dataset: Dataset, num_names: int
 ):
-    """A genuine duplicate sharing a distinctive name must outrank the flood of
-    pairs that only share a common forename and country (issue #349). Extra
-    aliases on the duplicate must not dilute its rank."""
+    """Ensure distinctive names outrank common-token noise despite aliases."""
     linker = Linker({})
     store = SimpleMemoryStore(test_dataset, linker)
     writer = store.writer()
-    # transliterations and different-script variants: distinct fingerprints
-    # AND distinct name parts, so both name-field and np-field dilution under
-    # a length-normalising formula are exercised
+    # Vary full-name fingerprints and name parts to exercise both token classes.
     names = [
         "Journal Atlas Publishing House",
         "Journal Atlas Publishing House Ltd",

--- a/tests/blocker/test_index.py
+++ b/tests/blocker/test_index.py
@@ -1,3 +1,5 @@
+import math
+import pytest
 from pathlib import Path
 from followthemoney import Dataset, StatementEntity
 
@@ -141,10 +143,11 @@ def test_index_pairs(dstore: SimpleMemoryStore, dindex: Index):
     )
     bmw_score = [score for pair, score in pairs if bmw == pair][0]
 
-    # More tokens in BMW means lower TF, reducing the score
+    # The Quandt pair shares its full name fingerprint; the BMW pair differs
+    # by one name part and only connects via individual parts.
     assert jq_score > bmw_score, (jq_score, bmw_score)
-    assert jq_score > 10.0, jq_score
-    assert 3.0 < bmw_score < 100.0, bmw_score
+    assert jq_score > 100.0, jq_score
+    assert 50.0 < bmw_score < 200.0, bmw_score
 
     # FERRING Arzneimittel GmbH <> Clou Container Leasing GmbH
     false_pos = (
@@ -303,7 +306,11 @@ def test_pairs_join_filtered_term_frequencies(
         index._build_frequencies()
 
         pairs = list(index.pairs())
-        assert pairs == [((Identifier.get("k2"), Identifier.get("k1")), 2.0)]
+        assert len(pairs) == 1
+        pair, score = pairs[0]
+        assert pair == (Identifier.get("k2"), Identifier.get("k1"))
+        # each side weighs 1.0 * idf, idf = 1 + ln(7 entities / df 2)
+        assert score == pytest.approx(2 * (1 + math.log(7 / 2)))
         assert index.con.execute(
             "SELECT COUNT(*) FROM term_frequencies_all WHERE token = 'np:stopped'"
         ).fetchone() == (5,)
@@ -407,7 +414,7 @@ def test_matching_stopwords_respect_cross_pair_cost(
         index._build_stopwords()
         index.con.execute("""
             CREATE OR REPLACE TABLE term_frequencies_all AS
-                SELECT schema, field, token, id, 1.0 AS tf
+                SELECT schema, field, token, id, 1.0 AS weight
                 FROM entries
         """)
         index.con.execute("""
@@ -475,7 +482,7 @@ def test_matching_stopwords_count_oriented_schema_pairs_once(
         index._build_stopwords()
         index.con.execute("""
             CREATE OR REPLACE TABLE term_frequencies_all AS
-                SELECT schema, field, token, id, 1.0 AS tf
+                SELECT schema, field, token, id, 1.0 AS weight
                 FROM entries
         """)
         index.con.execute("""
@@ -503,6 +510,64 @@ def test_matching_stopwords_count_oriented_schema_pairs_once(
         assert index.con.execute("SELECT COUNT(*) FROM matching_stopwords").fetchone()[
             0
         ] == 0
+    finally:
+        index.close()
+
+
+@pytest.mark.parametrize("num_names", [1, 7])
+def test_pairs_rank_distinctive_match_above_common_token_noise(
+    index_path: Path, test_dataset: Dataset, num_names: int
+):
+    """A genuine duplicate sharing a distinctive name must outrank the flood of
+    pairs that only share a common forename and country (issue #349). Extra
+    aliases on the duplicate must not dilute its rank."""
+    linker = Linker({})
+    store = SimpleMemoryStore(test_dataset, linker)
+    writer = store.writer()
+    names = ["Journal Atlas Publishing House"] + [
+        f"Journal Atlas Publishing House ({i})" for i in range(num_names - 1)
+    ]
+    writer.add_entity(
+        StatementEntity.from_data(
+            test_dataset,
+            {
+                "id": "journal-atlas",
+                "schema": "Company",
+                "properties": {"name": names},
+            },
+        )
+    )
+    writer.add_entity(
+        StatementEntity.from_data(
+            test_dataset,
+            {
+                "id": "fsf-atlas",
+                "schema": "Company",
+                "properties": {"name": ["Journal Atlas Publishing House"]},
+            },
+        )
+    )
+    for i in range(50):
+        writer.add_entity(
+            StatementEntity.from_data(
+                test_dataset,
+                {
+                    "id": f"decoy-{i}",
+                    "schema": "Person",
+                    "properties": {"name": ["Ahmad"], "country": ["iq"]},
+                },
+            )
+        )
+    writer.flush()
+
+    index = Index(store.default_view(), index_path)
+    try:
+        index.build()
+        pairs = list(index.pairs(max_pairs=2000))
+        genuine = (Identifier.get("journal-atlas"), Identifier.get("fsf-atlas"))
+        assert pairs[0][0] in (genuine, tuple(reversed(genuine))), pairs[0]
+        # a strict win, not a tie broken by luck
+        assert pairs[0][1] > pairs[1][1], (pairs[0], pairs[1])
     finally:
         index.close()
 


### PR DESCRIPTION
Fixes #349.

## The two defects

The pair score `sum(left.tf + right.tf)` with `tf = (count/field_len) × boost` had:

1. **No rarity term** — a shared common forename scored identically to a shared distinctive company name. Truth pairs tied with masses of common-token noise, and with no tie-break, `LIMIT` truncated arbitrarily within the band (72% of candidate rows discarded near-randomly in production).
2. **Field-length dilution** — every additional alias divided the tf of the name that actually matched. The median sanctions entity (2 names) had its match evidence halved; heavily-aliased entities (i.e. the best-documented sanctions targets) sank below single-common-token noise. 3.5% of exact-name duplicate pairs never surfaced within a 1M-pair budget; the worst ranked ~999k.

## The scoring change

Applied identically to both query paths — `pairs()` (internal dedupe) and `match_entities()` (cross-dataset matching/enrichment):

- **Presence × IDF weights**: `weight = boost × (1 + ln(N/df))`. Matching one of an entity's aliases is full evidence; rarity separates distinctive tokens from common ones. Smoothed so a token present in every entity keeps its boost rather than zeroing.
- **Alias dampening for np/sy tokens** (`÷ sqrt(name count)`): name-part and symbol tokens multiply with an entity's alias count without adding independent evidence. Exactly 1.0 for single-name entities, so registry/procurement-shaped data is untouched. The full-name fingerprint is exempt: exact name matches are never discounted.
- **Per-field log credit**: per pair and field, the best shared token counts in full and each additional one earns `(1 + ln n)` credit. Extra same-field tokens are mostly correlated (24 translations of one name ≠ 24 coincidences). Without this, multilingual alias families (e.g. IRGC provincial corps, named in ~24 EU languages) produce sibling pairs sharing 60–160 rare translated boilerplate parts that outscore genuine duplicates 40×. At small n the damping is gentle (n=2: −15%), so sparse single-name workloads are effectively scored by presence × IDF alone.
- **Deterministic tie-breaks** on both `ORDER BY`s.

No tuned constants — shapes only (log, sqrt).

## Validation

Benchmarked on the production sanctions scope (100,656 entities, 11.2M candidate pairs, `max_bucket_size=300`), ground truth = all 19,466 schema-compatible pairs sharing an exact-name fingerprint, computed exhaustively from the index:

| metric | main | this PR |
|---|---|---|
| truth recall@10k | 49.9% | 51.1% (theoretical max 51.4%) |
| truth recall@100k | 88.8% | **100.0%** |
| truth median / p90 / worst rank | 9,674 / 53,567 / 999,159 | 9,782 / 18,058 / **20,895** |
| head matcher acceptance ≥ 0.05 | 88.1% | 90.2% |
| 1M-pair stream time | 4.3s | 5.7s |

Every exact-name duplicate in the scope now surfaces within the first ~21k candidates; only 1,429 non-truth pairs interleave above the weakest truth pair, and spot-checking shows they are mostly genuine non-exact-name duplicates (transliterations, identifier matches). Ablations on the same corpus: the per-field log credit *or* the alias dampening alone each achieve the 100% recall@100k tail fix, but each alone leaves either head quality or the translation-flood suppression on the table; the combination dominates every variant measured on all metrics.

- `pytest tests/` — passes (new: decoy regression test asserting a genuine duplicate outranks common-token noise, parametrised over 1 and 7 name statements — the aliases are transliterations and different-script variants so both defects are exercised — with a vacuity guard pinning the expected pair count)
- `mypy --strict nomenklatura/` — clean
- Query plan shape verified unchanged (full external sort before and after; the extra sort keys and two-level aggregation add no memory footprint beyond DuckDB's spillable operators; build time unchanged)

## Downstream note: zavod `local_enricher` (superseded by #351)

`zavod/runner/local_enricher.py` bins candidates by `round(index_score)` and halts after `max_bin` (default 10) *distinct rounded values* — an absolute-scale assumption this PR's larger, more spread scores interact with. Measured on a 5k-subject self-match simulation: the walk's median depth drops from 75 to 60 candidates and cuts 1.1% of exact-name duplicate candidates before the matcher sees them.

**This is not a merge gate.** The improved ranking puts more true duplicates into the top-75 candidate lists in the first place (2,028 vs 1,954), so net enrichment recall improves even with zavod unmodified (2,005 surviving the walk vs 1,954 on main). The clean fix is #351 (per-subject truncation with a relative score cutoff inside the matching query), after which the `max_bin` walk is deleted from zavod entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
