### PR TITLE
Blocker: truncate match candidates inside the query, drop chunking

### DIFF
--- a/docs/reference/blocker.md
+++ b/docs/reference/blocker.md
@@ -2,12 +2,14 @@
 
 The blocking index finds candidate duplicate pairs by shared tokens, so that only a small fraction of all possible entity pairs needs to be scored.
 
-Comparing every entity against every other entity is quadratic: a dataset of one million entities has half a trillion pairs. Blocking cuts this down by tokenizing each entity — into name parts, phonetic forms, identifiers, and words — and only pairing entities that share at least one token. Each candidate pair gets a rough similarity score based on term frequency and per-field boost factors. That score ranks candidates for the more expensive [matching](matching.md) stage; it is not itself a match decision.
+Comparing every entity against every other entity is quadratic: a dataset of one million entities has half a trillion pairs. Blocking cuts this down by tokenizing each entity — into name parts, phonetic forms, identifiers, and words — and only pairing entities that share at least one token. Each candidate pair gets a rough similarity score that weighs shared tokens by their rarity across the index and per-field boost factors. That score ranks candidates for the more expensive [matching](matching.md) stage; it is not itself a match decision.
 
 The index is backed by [DuckDB](https://duckdb.org/). It keeps data in memory and spills to disk as it approaches the configured memory limit. Two environment variables control resource use:
 
-- `NOMENKLATURA_DUCKDB_MEMORY` — memory limit for the DuckDB buffer manager (e.g. `4GB`). DuckDB uses more memory than this setting in total, so leave headroom.
+- `NOMENKLATURA_DUCKDB_MEMORY` — memory limit in megabytes for the DuckDB buffer manager (e.g. `4000`). DuckDB uses more memory than this setting in total, so leave headroom.
 - `NOMENKLATURA_DUCKDB_THREADS` — number of threads DuckDB may use.
+
+When matching a batch of entities against the index (enrichment), each subject's candidate list is truncated inside the query: at most `max_candidates` candidates (default 75), and only candidates scoring at least `min_score_ratio` (default 0.1) of that subject's best candidate score. Set `min_score_ratio: 0` to disable the relative floor. By default the whole batch is matched in one query; setting `match_batch` to a positive number splits it into chunks of roughly that many subjects, trading throughput for a lower peak resource footprint on constrained hosts.
 
 The `nk xref` command builds a blocking index under its data path (`nomenklatura.data/xref-index` by default) and feeds the resulting candidate pairs to a scoring algorithm. See the [deduplication tutorial](../tutorial.md) for the full workflow.
 

--- a/docs/reference/blocker.md
+++ b/docs/reference/blocker.md
@@ -9,7 +9,7 @@ The index is backed by [DuckDB](https://duckdb.org/). It keeps data in memory an
 - `NOMENKLATURA_DUCKDB_MEMORY` — memory limit in megabytes for the DuckDB buffer manager (e.g. `4000`). DuckDB uses more memory than this setting in total, so leave headroom.
 - `NOMENKLATURA_DUCKDB_THREADS` — number of threads DuckDB may use.
 
-When matching a batch of entities against the index (enrichment), each subject's candidate list is truncated inside the query: at most `max_candidates` candidates (default 75), and only candidates scoring at least `min_score_ratio` (default 0.1) of that subject's best candidate score. Set `min_score_ratio: 0` to disable the relative floor. By default the whole batch is matched in one query; setting `match_batch` to a positive number splits it into chunks of roughly that many subjects, trading throughput for a lower peak resource footprint on constrained hosts.
+When matching a batch of entities against the index (enrichment), each subject's candidate list is truncated inside the query: at most `max_candidates` candidates (default 75), and only candidates scoring at least `min_score_ratio` (default 0.1) of that subject's best candidate score. Set `min_score_ratio: 0` to disable the relative floor. The whole batch is matched in one query; every operator in it spills to disk under the memory limit, and on severely constrained hosts reducing `NOMENKLATURA_DUCKDB_THREADS` lowers the per-query memory footprint further.
 
 The `nk xref` command builds a blocking index under its data path (`nomenklatura.data/xref-index` by default) and feeds the resulting candidate pairs to a scoring algorithm. See the [deduplication tutorial](../tutorial.md) for the full workflow.
 

--- a/nomenklatura/blocker/index.py
+++ b/nomenklatura/blocker/index.py
@@ -110,8 +110,6 @@ class Index(object):
         )
         self.max_pair_cost = _bucket_pair_cost(self.max_bucket_size)
         self.max_match_pair_cost = _bucket_pair_cost(self.max_bucket_size, cross=True)
-        # 0 disables chunking; set to bound per-query memory on constrained hosts.
-        self.match_batch: int = int(options.get("match_batch", 0))
         self.data_dir = data_dir.resolve()
         self.data_dir.mkdir(parents=True, exist_ok=True)
         self.duckdb_config: DuckDBConfig = {
@@ -137,13 +135,12 @@ class Index(object):
         log.info(
             "Blocker index configured: max_bucket_size=%d, "
             "pair cost cap=%d, matching pair cost cap=%d, "
-            "max_candidates=%d, min_score_ratio=%.2f, match_batch=%d",
+            "max_candidates=%d, min_score_ratio=%.2f",
             self.max_bucket_size,
             self.max_pair_cost,
             self.max_match_pair_cost,
             self.max_candidates,
             self.min_score_ratio,
-            self.match_batch,
         )
         self.duckdb_path = self.data_dir / "index.duckdb"
         self.con = duckdb.connect(self.duckdb_path, config=self.duckdb_config)
@@ -663,130 +660,67 @@ class Index(object):
         q = "SELECT COUNT(DISTINCT id) FROM matching_filtered"
         res = self.con.execute(q).fetchone()
         num_matching = res[0] if res is not None else 0
-        chunks = 1
-        if self.match_batch > 0:
-            chunks = max(1, num_matching // self.match_batch)
         self._log_matching_query_stats(num_matching)
 
-        chunk_table_query = """
-        CREATE OR REPLACE TABLE matching_chunks AS
-            WITH ids AS (SELECT DISTINCT id FROM matching_filtered)
-            SELECT id, ntile(?) OVER (ORDER BY id) as chunk FROM ids
+        log.info("Matching %d entities...", num_matching)
+        # Same per-field aggregation as pairs(), then per-subject top-K and a
+        # relative score floor inside the query, so DuckDB never sorts or
+        # ships candidate rows that would be discarded here (issue #351).
+        matches_query = """
+        WITH field_scores AS (
+            SELECT m.id AS matching_id, tf.id AS matches_id, tf.field AS field,
+                max(tf.weight) AS maxw, count(*) AS n
+            FROM matching_filtered m
+            JOIN term_frequencies_all tf
+            ON m.token = tf.token AND m.field = tf.field AND tf.id != m.id
+            INNER JOIN schemata s
+            ON s.left = m.schema AND s.right = tf.schema
+            GROUP BY m.id, tf.id, tf.field
+        ),
+        pair_scores AS (
+            SELECT matching_id, matches_id, sum(maxw * (1.0 + ln(n))) AS score
+            FROM field_scores
+            GROUP BY matching_id, matches_id
+        )
+        SELECT matching_id, matches_id, score
+        FROM (
+            SELECT matching_id, matches_id, score,
+                row_number() OVER w AS rn,
+                first_value(score) OVER w AS best
+            FROM pair_scores
+            WINDOW w AS (PARTITION BY matching_id ORDER BY score DESC, matches_id)
+        )
+        WHERE rn <= ? AND score >= best * ?
+        ORDER BY matching_id, rn
         """
-        self.con.execute(chunk_table_query, [chunks])
-        chunk_stats_query = """
-            SELECT
-                min(entities) AS min_entities,
-                avg(entities) AS avg_entities,
-                max(entities) AS max_entities
-            FROM (
-                SELECT chunk, count(*) AS entities
-                FROM matching_chunks
-                GROUP BY chunk
-            )
-        """
-        chunk_stats = self.con.execute(chunk_stats_query).fetchone()
-        if chunk_stats is not None and chunk_stats[0] is not None:
-            min_entities, avg_entities, max_entities = chunk_stats
-            log.info(
-                "Matching chunks built: min=%d avg=%.1f max=%d entities",
-                min_entities,
-                avg_entities,
-                max_entities,
-            )
-
-        log.info("Matching %d entities in %d chunks...", num_matching, chunks)
-        for chunk in range(1, chunks + 1):
-            # Same per-field aggregation as pairs(), then per-subject top-K and
-            # a relative score floor inside the query, so DuckDB never sorts or
-            # ships candidate rows that would be discarded here (issue #351).
-            chunk_query = """
-            WITH field_scores AS (
-                SELECT m.id AS matching_id, tf.id AS matches_id, tf.field AS field,
-                    max(tf.weight) AS maxw, count(*) AS n
-                FROM matching_chunks c
-                JOIN matching_filtered m ON c.id = m.id
-                JOIN term_frequencies_all tf
-                ON m.token = tf.token AND m.field = tf.field AND tf.id != m.id
-                INNER JOIN schemata s
-                ON s.left = m.schema AND s.right = tf.schema
-                WHERE c.chunk = ?
-                GROUP BY m.id, tf.id, tf.field
-            ),
-            pair_scores AS (
-                SELECT matching_id, matches_id, sum(maxw * (1.0 + ln(n))) AS score
-                FROM field_scores
-                GROUP BY matching_id, matches_id
-            )
-            SELECT matching_id, matches_id, score
-            FROM (
-                SELECT matching_id, matches_id, score,
-                    row_number() OVER w AS rn,
-                    first_value(score) OVER w AS best
-                FROM pair_scores
-                WINDOW w AS (PARTITION BY matching_id ORDER BY score DESC, matches_id)
-            )
-            WHERE rn <= ? AND score >= best * ?
-            ORDER BY matching_id, rn
-            """
-            started = perf_counter()
-            chunk_input_query = """
-                SELECT
-                    count(DISTINCT m.id) AS entities,
-                    count(*) AS rows,
-                    count(DISTINCT m.token) AS tokens
-                FROM matching_chunks c
-                JOIN matching_filtered m ON c.id = m.id
-                WHERE c.chunk = ?
-            """
-            chunk_input = self.con.execute(chunk_input_query, [chunk]).fetchone()
-            if chunk_input is not None:
-                chunk_entities, chunk_rows, chunk_tokens = chunk_input
-                log.info(
-                    "Matching chunk %d/%d input: %d entities, %d token rows, "
-                    "%d distinct tokens",
-                    chunk,
-                    chunks,
-                    chunk_entities,
-                    chunk_rows,
-                    chunk_tokens,
-                )
-            log.info("Matching chunk %d/%d...", chunk, chunks)
-            results = self.con.execute(
-                chunk_query, [chunk, self.max_candidates, self.min_score_ratio]
-            )
-            log.info(
-                "Matching chunk %d/%d query ready in %.2fs",
-                chunk,
-                chunks,
-                perf_counter() - started,
-            )
-            previous_id = None
-            matches: BlockingMatches = []
-            rows = 0
-            subjects = 0
-            while batch := results.fetchmany(BATCH_SIZE):
-                rows += len(batch)
-                for matching_id, match_id, score in batch:
-                    if matching_id != previous_id:
-                        if previous_id is not None:
-                            subjects += 1
-                            yield Identifier.get(previous_id), matches
-                        matches = []
-                        previous_id = matching_id
-                    matches.append((Identifier.get(match_id), score))
-            if previous_id is not None:
-                subjects += 1
-                yield Identifier.get(previous_id), matches
-            log.info(
-                "Matching chunk %d/%d complete: read %d candidate rows for "
-                "%d subjects in %.2fs",
-                chunk,
-                chunks,
-                rows,
-                subjects,
-                perf_counter() - started,
-            )
+        started = perf_counter()
+        results = self.con.execute(
+            matches_query, [self.max_candidates, self.min_score_ratio]
+        )
+        log.info("Matching query ready in %.2fs", perf_counter() - started)
+        previous_id = None
+        matches: BlockingMatches = []
+        rows = 0
+        subjects = 0
+        while batch := results.fetchmany(BATCH_SIZE):
+            rows += len(batch)
+            for matching_id, match_id, score in batch:
+                if matching_id != previous_id:
+                    if previous_id is not None:
+                        subjects += 1
+                        yield Identifier.get(previous_id), matches
+                    matches = []
+                    previous_id = matching_id
+                matches.append((Identifier.get(match_id), score))
+        if previous_id is not None:
+            subjects += 1
+            yield Identifier.get(previous_id), matches
+        log.info(
+            "Matching complete: read %d candidate rows for %d subjects in %.2fs",
+            rows,
+            subjects,
+            perf_counter() - started,
+        )
 
     def _log_matching_query_stats(self, num_matching: int) -> None:
         matching_stats_query = """

--- a/nomenklatura/blocker/index.py
+++ b/nomenklatura/blocker/index.py
@@ -57,6 +57,10 @@ log = logging.getLogger(__name__)
 
 BATCH_SIZE = 10_000
 DEFAULT_MAX_BUCKET_SIZE = 60
+# Matching candidates below this fraction of their subject's best score are
+# noise: they'd need the matcher to overrule an order-of-magnitude weaker
+# blocker signal. Equivalent to ten 20%-wide score bands (0.8^10).
+DEFAULT_MIN_SCORE_RATIO = 0.1
 
 
 def _bucket_pair_cost(bucket_size: int, cross: bool = False) -> int:
@@ -98,12 +102,16 @@ class Index(object):
     ):
         self.view = view
         self.max_candidates = int(options.get("max_candidates", 75))
+        self.min_score_ratio = float(
+            options.get("min_score_ratio", DEFAULT_MIN_SCORE_RATIO)
+        )
         self.max_bucket_size = int(
             options.get("max_bucket_size", DEFAULT_MAX_BUCKET_SIZE)
         )
         self.max_pair_cost = _bucket_pair_cost(self.max_bucket_size)
         self.max_match_pair_cost = _bucket_pair_cost(self.max_bucket_size, cross=True)
-        self.match_batch: int = int(options.get("match_batch", 1_000))
+        # 0 disables chunking; set to bound per-query memory on constrained hosts.
+        self.match_batch: int = int(options.get("match_batch", 0))
         self.data_dir = data_dir.resolve()
         self.data_dir.mkdir(parents=True, exist_ok=True)
         self.duckdb_config: DuckDBConfig = {
@@ -129,11 +137,12 @@ class Index(object):
         log.info(
             "Blocker index configured: max_bucket_size=%d, "
             "pair cost cap=%d, matching pair cost cap=%d, "
-            "max_candidates=%d, match_batch=%d",
+            "max_candidates=%d, min_score_ratio=%.2f, match_batch=%d",
             self.max_bucket_size,
             self.max_pair_cost,
             self.max_match_pair_cost,
             self.max_candidates,
+            self.min_score_ratio,
             self.match_batch,
         )
         self.duckdb_path = self.data_dir / "index.duckdb"
@@ -654,7 +663,9 @@ class Index(object):
         q = "SELECT COUNT(DISTINCT id) FROM matching_filtered"
         res = self.con.execute(q).fetchone()
         num_matching = res[0] if res is not None else 0
-        chunks = max(1, num_matching // self.match_batch)
+        chunks = 1
+        if self.match_batch > 0:
+            chunks = max(1, num_matching // self.match_batch)
         self._log_matching_query_stats(num_matching)
 
         chunk_table_query = """
@@ -686,23 +697,37 @@ class Index(object):
 
         log.info("Matching %d entities in %d chunks...", num_matching, chunks)
         for chunk in range(1, chunks + 1):
-            # Apply the same per-field aggregation used by pairs().
+            # Same per-field aggregation as pairs(), then per-subject top-K and
+            # a relative score floor inside the query, so DuckDB never sorts or
+            # ships candidate rows that would be discarded here (issue #351).
             chunk_query = """
-            SELECT matching_id, matches_id, sum(maxw * (1.0 + ln(n))) AS score
-                FROM (
-                    SELECT m.id AS matching_id, tf.id AS matches_id, tf.field AS field,
-                        max(tf.weight) AS maxw, count(*) AS n
-                    FROM matching_chunks c
-                    JOIN matching_filtered m ON c.id = m.id
-                    JOIN term_frequencies_all tf
-                    ON m.token = tf.token AND m.field = tf.field
-                    INNER JOIN schemata s
-                    ON s.left = m.schema AND s.right = tf.schema
-                    WHERE c.chunk = ?
-                    GROUP BY m.id, tf.id, tf.field
-                )
+            WITH field_scores AS (
+                SELECT m.id AS matching_id, tf.id AS matches_id, tf.field AS field,
+                    max(tf.weight) AS maxw, count(*) AS n
+                FROM matching_chunks c
+                JOIN matching_filtered m ON c.id = m.id
+                JOIN term_frequencies_all tf
+                ON m.token = tf.token AND m.field = tf.field AND tf.id != m.id
+                INNER JOIN schemata s
+                ON s.left = m.schema AND s.right = tf.schema
+                WHERE c.chunk = ?
+                GROUP BY m.id, tf.id, tf.field
+            ),
+            pair_scores AS (
+                SELECT matching_id, matches_id, sum(maxw * (1.0 + ln(n))) AS score
+                FROM field_scores
                 GROUP BY matching_id, matches_id
-                ORDER BY matching_id, score DESC, matches_id
+            )
+            SELECT matching_id, matches_id, score
+            FROM (
+                SELECT matching_id, matches_id, score,
+                    row_number() OVER w AS rn,
+                    first_value(score) OVER w AS best
+                FROM pair_scores
+                WINDOW w AS (PARTITION BY matching_id ORDER BY score DESC, matches_id)
+            )
+            WHERE rn <= ? AND score >= best * ?
+            ORDER BY matching_id, rn
             """
             started = perf_counter()
             chunk_input_query = """
@@ -727,7 +752,9 @@ class Index(object):
                     chunk_tokens,
                 )
             log.info("Matching chunk %d/%d...", chunk, chunks)
-            results = self.con.execute(chunk_query, [chunk])
+            results = self.con.execute(
+                chunk_query, [chunk, self.max_candidates, self.min_score_ratio]
+            )
             log.info(
                 "Matching chunk %d/%d query ready in %.2fs",
                 chunk,
@@ -741,23 +768,16 @@ class Index(object):
             while batch := results.fetchmany(BATCH_SIZE):
                 rows += len(batch)
                 for matching_id, match_id, score in batch:
-                    # first row
-                    if previous_id is None:
-                        previous_id = matching_id
-                    # Next pair of subject and candidates
                     if matching_id != previous_id:
-                        if matches:
+                        if previous_id is not None:
                             subjects += 1
                             yield Identifier.get(previous_id), matches
                         matches = []
                         previous_id = matching_id
-                    if len(matches) <= self.max_candidates:
-                        matches.append((Identifier.get(match_id), score))
-            # Last pair or subject and candidates
-            if matches and previous_id is not None:
+                    matches.append((Identifier.get(match_id), score))
+            if previous_id is not None:
                 subjects += 1
-                yield Identifier.get(previous_id), matches[: self.max_candidates]
-                # yield Identifier.get(previous_id), matches
+                yield Identifier.get(previous_id), matches
             log.info(
                 "Matching chunk %d/%d complete: read %d candidate rows for "
                 "%d subjects in %.2fs",

--- a/tests/blocker/test_index.py
+++ b/tests/blocker/test_index.py
@@ -27,11 +27,12 @@ def make_manual_index(
     entries: list[tuple[str, str, str, str, int]],
     schemata: list[tuple[str, str]],
     max_bucket_size: int,
+    options: dict[str, object] | None = None,
 ) -> Index:
     index = Index(
         dstore.default_view(),
         index_path,
-        options={"max_bucket_size": max_bucket_size},
+        options={"max_bucket_size": max_bucket_size, **(options or {})},
     )
     index.con.execute("""
         CREATE OR REPLACE TABLE entries
@@ -41,6 +42,33 @@ def make_manual_index(
     index.con.execute("""CREATE OR REPLACE TABLE schemata ("left" TEXT, "right" TEXT)""")
     index.con.executemany("INSERT INTO schemata VALUES (?, ?)", schemata)
     return index
+
+
+def run_matching(
+    index: Index,
+    matching_rows: list[tuple[str, str, str, str, int]],
+    boosts: dict[str, float] | None = None,
+) -> dict[str, list[tuple[str, float]]]:
+    """Run the matching query path over manually inserted subject rows."""
+    index.con.execute("CREATE OR REPLACE TABLE boosts (field TEXT, boost FLOAT)")
+    for field, boost in (boosts or {}).items():
+        index.con.execute("INSERT INTO boosts VALUES (?, ?)", [field, boost])
+    index._build_frequencies()
+    index.con.execute("""
+        CREATE OR REPLACE TABLE matching
+            (schema TEXT, id TEXT, field TEXT, token TEXT, count INT)
+    """)
+    index.con.executemany("INSERT INTO matching VALUES (?, ?, ?, ?, ?)", matching_rows)
+    index._build_matching_stopwords()
+    index._apply_stopwords(
+        "matching",
+        "matching_filtered",
+        stopwords_table="matching_stopwords",
+    )
+    return {
+        str(subject): [(str(match_id), score) for match_id, score in candidates]
+        for subject, candidates in index._find_matches()
+    }
 
 
 def test_max_bucket_size_configures_pair_cost_caps(
@@ -644,5 +672,199 @@ def test_index_xref(test_dataset: Dataset, dstore: SimpleMemoryStore, dindex: In
     if "b" in matches:
         assert matches["b"][0][1] < a_top[1], matches["b"]
 
-    # for ident, matches in matches:
-    #     pass
+
+# Candidate ladder: entity e{i} shares i+1 distinct np tokens with subject q,
+# so scores strictly increase with i (same token weight, log token credit).
+LADDER_ENTRIES = [
+    ("Person", f"e{i}", "np", f"np:t{i}_{j}", 1)
+    for i in range(5)
+    for j in range(i + 1)
+]
+LADDER_MATCHING = [
+    ("Person", "q", "np", f"np:t{i}_{j}", 1) for i in range(5) for j in range(i + 1)
+]
+
+
+def test_matching_truncates_to_max_candidates_in_query(
+    index_path: Path, dstore: SimpleMemoryStore
+):
+    index = make_manual_index(
+        index_path,
+        dstore,
+        LADDER_ENTRIES,
+        [("Person", "Person")],
+        max_bucket_size=10,
+        options={"max_candidates": 3},
+    )
+    try:
+        matches = run_matching(index, LADDER_MATCHING)
+        assert [mid for mid, _ in matches["q"]] == ["e4", "e3", "e2"]
+        scores = [score for _, score in matches["q"]]
+        assert scores == sorted(scores, reverse=True)
+    finally:
+        index.close()
+
+
+def test_matching_keeps_all_candidates_at_exact_max_candidates(
+    index_path: Path, dstore: SimpleMemoryStore
+):
+    index = make_manual_index(
+        index_path,
+        dstore,
+        LADDER_ENTRIES,
+        [("Person", "Person")],
+        max_bucket_size=10,
+        options={"max_candidates": 5},
+    )
+    try:
+        matches = run_matching(index, LADDER_MATCHING)
+        assert [mid for mid, _ in matches["q"]] == ["e4", "e3", "e2", "e1", "e0"]
+    finally:
+        index.close()
+
+
+# Three candidates with boost-separated scores: eA (name, boost 15) is the
+# best, eC (np, boost 5) sits at 1/3 of it, eB (word, boost 0.5) at 1/30 —
+# below the default 0.1 relative score floor.
+FLOOR_BOOSTS = {"name": 15.0, "np": 5.0, "word": 0.5}
+FLOOR_ENTRIES = [
+    ("Person", "eA", "name", "fp:acmeholdings", 1),
+    ("Person", "eC", "np", "np:acme", 1),
+    ("Person", "eB", "word", "w:junk", 1),
+]
+FLOOR_MATCHING = [
+    ("Person", "q", "name", "fp:acmeholdings", 1),
+    ("Person", "q", "np", "np:acme", 1),
+    ("Person", "q", "word", "w:junk", 1),
+]
+
+
+def test_matching_applies_relative_score_floor(
+    index_path: Path, dstore: SimpleMemoryStore
+):
+    index = make_manual_index(
+        index_path,
+        dstore,
+        FLOOR_ENTRIES,
+        [("Person", "Person")],
+        max_bucket_size=10,
+    )
+    try:
+        matches = run_matching(index, FLOOR_MATCHING, boosts=FLOOR_BOOSTS)
+        assert [mid for mid, _ in matches["q"]] == ["eA", "eC"]
+    finally:
+        index.close()
+
+
+def test_matching_score_floor_disabled_at_zero(
+    index_path: Path, dstore: SimpleMemoryStore
+):
+    index = make_manual_index(
+        index_path,
+        dstore,
+        FLOOR_ENTRIES,
+        [("Person", "Person")],
+        max_bucket_size=10,
+        options={"min_score_ratio": 0.0},
+    )
+    try:
+        matches = run_matching(index, FLOOR_MATCHING, boosts=FLOOR_BOOSTS)
+        assert [mid for mid, _ in matches["q"]] == ["eA", "eC", "eB"]
+    finally:
+        index.close()
+
+
+def test_matching_score_floor_is_per_subject(
+    index_path: Path, dstore: SimpleMemoryStore
+):
+    """A weak-evidence subject keeps its best candidate even when another
+    subject in the batch has a much stronger best (the floor must not leak
+    across window partitions)."""
+    entries = FLOOR_ENTRIES + [("Person", "eD", "word", "w:other", 1)]
+    index = make_manual_index(
+        index_path,
+        dstore,
+        entries,
+        [("Person", "Person")],
+        max_bucket_size=10,
+    )
+    try:
+        matching = FLOOR_MATCHING + [("Person", "q2", "word", "w:other", 1)]
+        matches = run_matching(index, matching, boosts=FLOOR_BOOSTS)
+        assert [mid for mid, _ in matches["q"]] == ["eA", "eC"]
+        assert [mid for mid, _ in matches["q2"]] == ["eD"]
+    finally:
+        index.close()
+
+
+def test_matching_excludes_subject_from_own_candidates(
+    index_path: Path, dstore: SimpleMemoryStore
+):
+    entries = [
+        ("Person", "e1", "np", "np:tok", 1),
+        ("Person", "e2", "np", "np:tok", 1),
+    ]
+    index = make_manual_index(
+        index_path,
+        dstore,
+        entries,
+        [("Person", "Person")],
+        max_bucket_size=10,
+    )
+    try:
+        matches = run_matching(index, [("Person", "e1", "np", "np:tok", 1)])
+        assert [mid for mid, _ in matches["e1"]] == ["e2"]
+    finally:
+        index.close()
+
+
+def test_matching_orders_equal_scores_by_candidate_id(
+    index_path: Path, dstore: SimpleMemoryStore
+):
+    entries = [
+        ("Person", cid, "np", "np:shared", 1) for cid in ("idxc", "idxa", "idxb")
+    ]
+    index = make_manual_index(
+        index_path,
+        dstore,
+        entries,
+        [("Person", "Person")],
+        max_bucket_size=10,
+    )
+    try:
+        matches = run_matching(index, [("Person", "q", "np", "np:shared", 1)])
+        assert [mid for mid, _ in matches["q"]] == ["idxa", "idxb", "idxc"]
+    finally:
+        index.close()
+
+
+def test_matching_chunked_matches_single_chunk(
+    index_path: Path, dstore: SimpleMemoryStore
+):
+    entries = [
+        ("Person", f"{prefix}{i}", "np", f"np:t{i}", 1)
+        for i in range(7)
+        for prefix in ("a", "b")
+    ]
+    index = make_manual_index(
+        index_path,
+        dstore,
+        entries,
+        [("Person", "Person")],
+        max_bucket_size=10,
+    )
+    try:
+        matching = [("Person", f"q{i}", "np", f"np:t{i}", 1) for i in range(7)]
+        single = run_matching(index, matching)
+        assert len(single) == 7
+        assert [mid for mid, _ in single["q0"]] == ["a0", "b0"]
+
+        # 7 subjects with match_batch=2 -> 3 uneven ntile chunks
+        index.match_batch = 2
+        chunked = {
+            str(subject): [(str(match_id), score) for match_id, score in candidates]
+            for subject, candidates in index._find_matches()
+        }
+        assert chunked == single
+    finally:
+        index.close()

--- a/tests/blocker/test_index.py
+++ b/tests/blocker/test_index.py
@@ -838,7 +838,7 @@ def test_matching_orders_equal_scores_by_candidate_id(
         index.close()
 
 
-def test_matching_chunked_matches_single_chunk(
+def test_matching_yields_all_subjects_with_candidates(
     index_path: Path, dstore: SimpleMemoryStore
 ):
     entries = [
@@ -855,16 +855,9 @@ def test_matching_chunked_matches_single_chunk(
     )
     try:
         matching = [("Person", f"q{i}", "np", f"np:t{i}", 1) for i in range(7)]
-        single = run_matching(index, matching)
-        assert len(single) == 7
-        assert [mid for mid, _ in single["q0"]] == ["a0", "b0"]
-
-        # 7 subjects with match_batch=2 -> 3 uneven ntile chunks
-        index.match_batch = 2
-        chunked = {
-            str(subject): [(str(match_id), score) for match_id, score in candidates]
-            for subject, candidates in index._find_matches()
-        }
-        assert chunked == single
+        matches = run_matching(index, matching)
+        assert len(matches) == 7
+        for i in range(7):
+            assert [mid for mid, _ in matches[f"q{i}"]] == [f"a{i}", f"b{i}"]
     finally:
         index.close()


### PR DESCRIPTION
Stacked on #350; closes #351.

`Index._find_matches()` previously sorted and shipped every candidate row out of DuckDB and truncated in Python, and downstream consumers (zavod's `local_enricher`) compensated with the absolute-scale `max_bin` walk. Now that the blocker score is a meaningful ranking, truncation moves into the matching query:

- **Per-subject top-K + relative score floor in SQL**: `row_number()`/`first_value()` over `(PARTITION BY matching_id ORDER BY score DESC, matches_id)`, filtered to `rn <= max_candidates AND score >= best * min_score_ratio`. New `min_score_ratio` option (default 0.1 ≈ the ten-20%-band walk validated in #349); `0` disables.
- **Self-match exclusion**: a subject present in the indexed view no longer receives itself as a candidate (it burned a top-K slot and would have inflated the relative floor).
- **`match_batch` chunking deleted**: measured on the largest local store, chunking produced identical output slightly slower, and DuckDB spills the whole operator chain under `memory_limit` down to a 512MB budget (with reduced threads). Constrained hosts tune `NOMENKLATURA_DUCKDB_THREADS` instead.
- Fixes an off-by-one where every subject except the last per chunk received `max_candidates + 1` candidates.

## Measurements

Index = ru_egrul external store (272,848 entities), subjects = sanctions collection under the prod topic/schema filter (50,066 subjects with candidates), `max_candidates: 200`, DuckDB `memory_limit` 3500MB, 11 threads. Truth = all schema-compatible subject×index pairs sharing an exact-name fingerprint (17,908 pairs) or identifier/phone/email token (13,666 pairs), computed exhaustively.

| config | time | peak RSS | candidate rows | truth name / identifier |
|---|---|---|---|---|
| floor off (baseline) | 28.8s | 2.6GB | 2,066,914 | 100% / 100% |
| floor 0.1 (default) | 27.0s | 2.6GB | 1,117,258 | 100% / 100% |
| floor 0.1, chunked 300 | 32.5s | 1.8GB | identical | 100% / 100% |
| floor 0.1, 512MB / 2 threads | 28.6s | 1.7GB | identical | 100% / 100% |

The floor cuts 46% of candidate rows (depth p50 12→7, p90 147→63) with zero truth loss on either evidence class — identifier-only matches score high enough on their own to clear it. At a 512MB limit with default threads DuckDB fails explicitly with an actionable error rather than emitting partial results.

Follow-up (zavod): delete the `max_bin` walk from `local_enricher` and drop the now-obsolete `max_bin` / `match_batch` keys from external dataset configs; `index_options.max_candidates` pins deserve re-tuning since they now directly bound matcher work per subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)