### PR TITLE
Add CSV export/import for resolver edges

### DIFF
--- a/nomenklatura/cli.py
+++ b/nomenklatura/cli.py
@@ -385,6 +385,17 @@ def dump_resolver(target: Path, format: str, include_deleted: bool) -> None:
             resolver.dump(target)
 
 
+@cli.command("dump-mapping", help="Dump entity_id -> canonical_id mapping to CSV")
+@click.argument("target", type=OutPath)
+def dump_mapping(target: Path) -> None:
+    linker = _get_linker()
+    with open(target, "w") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["entity_id", "canonical_id"])
+        for entity_id, canonical_id in sorted(linker.mappings(), key=lambda m: (m[1], m[0])):
+            writer.writerow([entity_id, canonical_id])
+
+
 @cli.command("bench", help="Benchmark a matching algorithm")
 @click.argument("name", type=str)
 @click.argument("pairs_file", type=InPath)

--- a/nomenklatura/cli.py
+++ b/nomenklatura/cli.py
@@ -1,3 +1,4 @@
+import csv
 import shutil
 import yaml
 import click
@@ -16,6 +17,7 @@ from nomenklatura.db import make_session, Session
 from nomenklatura.matching import train_v1_matcher, train_erun_matcher
 from nomenklatura.store import load_entity_file_store
 from nomenklatura.resolver import Resolver, Linker
+from nomenklatura.resolver.edge import Edge
 from nomenklatura.enrich import Enricher, make_enricher, match, enrich
 from nomenklatura.matching import get_algorithm, DedupeAlgorithm
 from nomenklatura.xref import xref as run_xref
@@ -334,20 +336,53 @@ def statements_apply(infile: Path, outpath: Path, format: str) -> None:
         write_statements(outfh, format, _generate())
 
 
+EDGE_FIELDS = ["target", "source", "judgement", "score", "user", "created_at", "deleted_at"]
+EDGE_FORMATS = ["jsonl", "csv"]
+
+
 @cli.command("load-resolver", help="Load resolver edges from file into database")
 @click.argument("source", type=InPath)
-def load_resolver(source: Path) -> None:
+@click.option("-f", "--format", type=click.Choice(EDGE_FORMATS), default="jsonl")
+def load_resolver(source: Path, format: str) -> None:
     with make_session() as session:
         resolver = Resolver[Entity](session, create=True)
-        resolver.load(source)
+        if format == "csv":
+
+            def _read_edges() -> Generator[Edge, None, None]:
+                with open(source, "r") as fh:
+                    for row in csv.DictReader(fh):
+                        yield Edge.from_dict(row)
+
+            resolver.load_edges(_read_edges())
+        else:
+            resolver.load(source)
 
 
 @cli.command("dump-resolver", help="Dump resolver decisions from database to file")
 @click.argument("target", type=OutPath)
-def dump_resolver(target: Path) -> None:
+@click.option("-f", "--format", type=click.Choice(EDGE_FORMATS), default="jsonl")
+@click.option(
+    "--include-deleted",
+    is_flag=True,
+    default=False,
+    help="Export soft-deleted edges as well (CSV only)",
+)
+def dump_resolver(target: Path, format: str, include_deleted: bool) -> None:
+    if include_deleted and format != "csv":
+        raise click.BadOptionUsage(
+            "--include-deleted",
+            "The jsonl line format cannot represent deleted edges; use -f csv.",
+        )
     with make_session() as session:
         resolver = Resolver[Entity](session, create=True)
-        resolver.dump(target)
+        if format == "csv":
+            with open(target, "w") as fh:
+                writer = csv.DictWriter(fh, fieldnames=EDGE_FIELDS)
+                writer.writeheader()
+                for edge in resolver.all_edges(include_deleted=include_deleted):
+                    writer.writerow(edge.to_dict())
+        else:
+            resolver.dump(target)
 
 
 @cli.command("bench", help="Benchmark a matching algorithm")

--- a/nomenklatura/resolver/edge.py
+++ b/nomenklatura/resolver/edge.py
@@ -96,12 +96,17 @@ class Edge(object):
 
     @classmethod
     def from_dict(cls, data: Union[RowMapping, Dict[str, Any]]) -> "Edge":
+        # Accept rows from csv.DictReader, where every value is a string and
+        # missing values arrive as "" rather than None.
+        score: Union[None, str, float] = data.get("score")
+        if isinstance(score, str):
+            score = float(score) if len(score) else None
         return cls(
             left_id=data["target"],
             right_id=data["source"],
             judgement=Judgement(data["judgement"]),
-            score=data["score"],
-            user=data["user"],
-            created_at=data.get("created_at"),
-            deleted_at=data.get("deleted_at"),
+            score=score,
+            user=data.get("user") or None,
+            created_at=data.get("created_at") or None,
+            deleted_at=data.get("deleted_at") or None,
         )

--- a/nomenklatura/resolver/linker.py
+++ b/nomenklatura/resolver/linker.py
@@ -58,15 +58,20 @@ class Linker(Generic[SE]):
             return cluster[0]
         return entity_id
 
+    def mappings(self) -> Generator[Tuple[str, str], None, None]:
+        """Yield (entity_id, canonical_id) for every known identifier, including
+        the canonical itself. Use this to export the resolution outcome as a
+        join table, without edges or judgement history."""
+        for entity_id, cluster in self._mapping.items():
+            yield entity_id, cluster[0]
+
     def canonicals(self) -> Generator[Identifier, None, None]:
         """Return all the canonical cluster identifiers."""
-        seen: Set[str] = set()
-        for cluster in self._mapping.values():
-            canonical = cluster[0]
-            if canonical not in seen:
-                ident = Identifier.get(canonical)
+        # Each canonical occurs exactly once in the mapping: as its self-row.
+        for entity_id, canonical_id in self.mappings():
+            if entity_id == canonical_id:
+                ident = Identifier.get(canonical_id)
                 if ident.canonical:
-                    seen.add(canonical)
                     yield ident
 
     def get_referents(self, canonical_id: str, canonicals: bool = True) -> Set[str]:

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -6,7 +6,7 @@
 from datetime import timedelta
 import getpass
 import logging
-from typing import Any, Dict, Generator, List, Optional, Set, Tuple
+from typing import Any, Dict, Generator, Iterable, List, Optional, Set, Tuple
 from rigour.ids.wikidata import is_qid
 from rigour.time import utc_now
 from sqlalchemy import (
@@ -619,36 +619,60 @@ class Resolver(Linker[SE]):
                 stmt = stmt.clone(value=canon_value)
         return stmt
 
+    def all_edges(
+        self,
+        include_deleted: bool = False,
+        include_suggestions: bool = False,
+    ) -> Generator[Edge, None, None]:
+        """Iterate the resolver's edges in chronological order.
+
+        Use this to export decisions in a format of your choosing (cf.
+        `dump()` for the JSON lines version). The chronological order makes
+        the stream safe to feed back via `load_edges()`: later edges supersede
+        earlier ones for the same pair.
+
+        By default only live, judged edges are returned; soft-deleted edges
+        and NO_JUDGEMENT suggestions can be opted in via the flags."""
+        stmt = self._table.select()
+        if not include_deleted:
+            stmt = stmt.where(self._table.c.deleted_at.is_(None))
+        if not include_suggestions:
+            stmt = stmt.where(self._table.c.judgement != Judgement.NO_JUDGEMENT.value)
+        stmt = stmt.order_by(self._table.c.created_at.asc())
+        cursor = self._session.execute(stmt)
+        for row in cursor.yield_per(20000):
+            yield Edge.from_dict(row._mapping)
+
+    def load_edges(self, edges: Iterable[Edge]) -> None:
+        """Write a stream of edges into the database, superseding any live
+        edge for the same pair. Counterpart to `all_edges()`."""
+        edge_count = 0
+        for edge in edges:
+            self._register(edge)
+            edge_count += 1
+            if edge_count % 10000 == 0:
+                log.info("Loaded %s edges." % edge_count)
+        log.info("Done. Loaded %s edges." % edge_count)
+        self._update_from_db()
+
     def dump(self, path: PathLike) -> None:
         """Store the resolver adjacency list to a plain text JSON list.
 
         Only live edges are exported: the line format has no deletion field,
         so including soft-deleted edges would resurrect them on load."""
-        stmt = self._table.select()
-        stmt = stmt.where(self._table.c.judgement != Judgement.NO_JUDGEMENT.value)
-        stmt = stmt.where(self._table.c.deleted_at.is_(None))
-        stmt = stmt.order_by(self._table.c.created_at.asc())
         with open(path, "w") as fh:
-            cursor = self._session.execute(stmt)
-            for row in cursor.yield_per(20000):
-                edge = Edge.from_dict(row._mapping)
+            for edge in self.all_edges():
                 fh.write(edge.to_line())
 
     def load(self, path: PathLike) -> None:
         """Load edges directly into the database"""
-        edge_count = 0
-        with open(path, "r") as fh:
-            while True:
-                line = fh.readline()
-                if not line:
-                    break
-                edge = Edge.from_line(line)
-                self._register(edge)
-                edge_count += 1
-                if edge_count % 10000 == 0:
-                    log.info("Loaded %s edges." % edge_count)
-        log.info("Done. Loaded %s edges." % edge_count)
-        self._update_from_db()
+
+        def _read_edges() -> Generator[Edge, None, None]:
+            with open(path, "r") as fh:
+                for line in fh:
+                    yield Edge.from_line(line)
+
+        self.load_edges(_read_edges())
 
     def __repr__(self) -> str:
         parts = self._session.engine.url

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -362,6 +362,34 @@ def test_resolver_load_edges(
     assert edge.score == 7.0
 
 
+def test_linker_mappings(resolver: Resolver[StatementEntity], db_session):
+    canon_a = resolver.decide("a1", "a2", Judgement.POSITIVE)
+    resolver.decide(canon_a, "a3", Judgement.POSITIVE)
+    resolver.decide("a2", "b2", Judgement.NEGATIVE)
+    resolver.suggest("a1", "c1", 7.0)
+
+    mappings = dict(resolver.get_linker().mappings())
+    assert mappings == {
+        "a1": canon_a.id,
+        "a2": canon_a.id,
+        "a3": canon_a.id,
+        canon_a.id: canon_a.id,
+    }
+
+    # Merging two clusters leaves the losing canonical behind as a stale
+    # intermediate that must still resolve to the winning canonical:
+    canon_d = resolver.decide("d1", "d2", Judgement.POSITIVE)
+    resolver.decide("a1", "d1", Judgement.POSITIVE)
+    merged = resolver.get_canonical("a1")
+    assert merged in (canon_a.id, canon_d.id)
+
+    mappings = dict(resolver.get_linker().mappings())
+    assert len(mappings) == 7, mappings
+    assert set(mappings.values()) == {merged}
+    assert mappings[canon_a.id] == merged
+    assert mappings[canon_d.id] == merged
+
+
 def test_edge_csv_roundtrip():
     edges = [
         Edge("a1", "a2", judgement=Judgement.POSITIVE, user="alice", created_at="2024"),

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,4 +1,6 @@
+from csv import DictReader, DictWriter
 from datetime import timedelta
+from io import StringIO
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Dict, Tuple
@@ -306,6 +308,83 @@ def test_resolver_store_load(
 
         edge = other_table_resolver.get_edge("a1", "c1")
         assert edge is None, edge
+
+
+def test_resolver_all_edges(resolver: Resolver[StatementEntity], db_session):
+    canon = resolver.decide("a1", "a2", Judgement.POSITIVE)
+    resolver.decide("a2", "b2", Judgement.NEGATIVE)
+    resolver.decide(canon, "a3", Judgement.POSITIVE)
+    resolver.remove("a3")
+    resolver.suggest("a1", "c1", 7.0)
+
+    live = list(resolver.all_edges())
+    assert len(live) == 3, live
+    assert all(e.deleted_at is None for e in live)
+    assert all(e.judgement != Judgement.NO_JUDGEMENT for e in live)
+
+    with_suggestions = list(resolver.all_edges(include_suggestions=True))
+    assert len(with_suggestions) == 4, with_suggestions
+    suggested = [e for e in with_suggestions if e.judgement == Judgement.NO_JUDGEMENT]
+    assert len(suggested) == 1
+    assert suggested[0].score == 7.0
+
+    with_deleted = list(resolver.all_edges(include_deleted=True))
+    assert len(with_deleted) == 4, with_deleted
+    deleted = [e for e in with_deleted if e.deleted_at is not None]
+    assert len(deleted) == 1
+    assert Identifier.get("a3") in deleted[0].key
+
+    everything = list(resolver.all_edges(include_deleted=True, include_suggestions=True))
+    assert len(everything) == 5, everything
+    stamps = [e.created_at for e in everything]
+    assert stamps == sorted(stamps)
+
+
+def test_resolver_load_edges(
+    resolver: Resolver[StatementEntity], other_table_resolver: Resolver[StatementEntity]
+):
+    canon_a = resolver.decide("a1", "a2", Judgement.POSITIVE)
+    resolver.decide(canon_a, "a3", Judgement.POSITIVE)
+    resolver.remove("a3")
+    resolver.decide("a2", "b2", Judgement.NEGATIVE)
+    resolver.suggest("a1", "c1", 7.0)
+
+    edges = list(resolver.all_edges(include_deleted=True, include_suggestions=True))
+    other_table_resolver.load_edges(edges)
+
+    assert other_table_resolver.get_canonical("a1") == canon_a
+    # The removed a3 edge travels as a tombstone and must stay deleted:
+    assert other_table_resolver.get_canonical("a3") == "a3"
+    assert other_table_resolver.get_edge(canon_a, "a3") is None
+    assert len(list(other_table_resolver.get_judgements())) == 3
+    edge = other_table_resolver.get_edge("a1", "c1")
+    assert edge is not None, edge
+    assert edge.score == 7.0
+
+
+def test_edge_csv_roundtrip():
+    edges = [
+        Edge("a1", "a2", judgement=Judgement.POSITIVE, user="alice", created_at="2024"),
+        Edge("b1", "b2", judgement=Judgement.NO_JUDGEMENT, score=7.0, created_at="2024"),
+        Edge("c1", "c2", judgement=Judgement.NEGATIVE, created_at="2024", deleted_at="2025"),
+    ]
+    fields = ["target", "source", "judgement", "score", "user", "created_at", "deleted_at"]
+    buffer = StringIO()
+    writer = DictWriter(buffer, fieldnames=fields)
+    writer.writeheader()
+    for edge in edges:
+        writer.writerow(edge.to_dict())
+
+    buffer.seek(0)
+    read = [Edge.from_dict(row) for row in DictReader(buffer)]
+    assert read == edges
+    assert read[0].user == "alice"
+    assert read[0].score is None
+    assert read[1].score == 7.0
+    assert read[1].user is None
+    assert read[1].deleted_at is None
+    assert read[2].judgement == Judgement.NEGATIVE
+    assert read[2].deleted_at == "2025"
 
 
 def test_resolver_candidates(resolver: Resolver[StatementEntity], db_session):


### PR DESCRIPTION
Refactors `Resolver.dump()`/`load()` onto two format-agnostic primitives so the CLI can serialize edges in more than one format:

* `Resolver.all_edges(include_deleted=False, include_suggestions=False)` — generator over the edge table in chronological order (load-bearing: on re-load, later edges supersede earlier live edges for the same pair, so a chronological stream reproduces final state).
* `Resolver.load_edges(edges)` — registers a stream of edges; `load()` is now the jsonl special case.

CLI changes:

* `dump-resolver` and `load-resolver` gain `-f/--format {jsonl,csv}`, defaulting to `jsonl` — existing usage is unaffected.
* CSV columns are the `Edge.to_dict()` fields: `target, source, judgement, score, user, created_at, deleted_at`.
* Because CSV carries `deleted_at`, `dump-resolver -f csv --include-deleted` preserves soft-delete tombstones through a roundtrip — the only lossless way to move resolver state between databases. The flag errors out for jsonl, whose positional line format cannot represent deleted edges.
* `Edge.from_dict()` now tolerates `csv.DictReader` rows (all-string values, `""` for missing).

Tested with new unit tests (`all_edges` filtering, `load_edges` tombstone-preserving roundtrip, CSV type coercion) plus a manual CLI smoke test: CSV dump with deleted edges from one SQLite database, load into a second, jsonl dumps of both are byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Second commit — `nk dump-mapping`:** exports the linker's resolution outcome as a two-column CSV (`entity_id,canonical_id`), one row per known identifier including canonical self-rows and stale intermediate canonicals, so any past reference resolves via a plain join. Backed by a new `Linker.mappings()` generator; `Linker.canonicals()` is rewritten on top of it, dropping its seen-set dedup.
