### PR TITLE
Fix mutable class defaults, zip strictness and blanket type ignores

### DIFF
--- a/nomenklatura/blocker/index.py
+++ b/nomenklatura/blocker/index.py
@@ -35,7 +35,7 @@ from collections.abc import Generator, Iterable
 from itertools import islice
 from pathlib import Path
 from time import perf_counter
-from typing import Any, TypeVar
+from typing import Any, ClassVar, TypeVar
 
 import duckdb
 from followthemoney import DS, SE, StatementEntity, model, registry
@@ -86,7 +86,7 @@ class Index:
     comparison is impractical.
     """
 
-    BOOSTS = {
+    BOOSTS: ClassVar[dict[str, float]] = {
         NAME_PART_FIELD: 5.0,
         WORD_FIELD: 0.5,
         registry.name.name: 15.0,
@@ -100,9 +100,10 @@ class Index:
         self,
         view: View[DS, SE],
         data_dir: Path,
-        options: dict[str, Any] = {},
+        options: dict[str, Any] | None = None,
     ):
         self.view = view
+        options = options or {}
         self.max_candidates = int(options.get("max_candidates", 75))
         self.min_score_ratio = float(
             options.get("min_score_ratio", DEFAULT_MIN_SCORE_RATIO)

--- a/nomenklatura/kv.py
+++ b/nomenklatura/kv.py
@@ -37,4 +37,4 @@ def b(s: str) -> bytes:
 
 def bv(s: bytes | str | float) -> bytes:
     """Decode bytes to a string."""
-    return s  # type: ignore
+    return s  # type: ignore[return-value]

--- a/nomenklatura/matching/erun/model.py
+++ b/nomenklatura/matching/erun/model.py
@@ -1,10 +1,10 @@
 import pickle
 from functools import cache
-from typing import cast
+from typing import ClassVar, cast
 
 import numpy as np
 from followthemoney import E
-from sklearn.pipeline import Pipeline  # type: ignore
+from sklearn.pipeline import Pipeline  # type: ignore[import-untyped]
 
 from nomenklatura.matching.erun.countries import (
     org_country_mismatch,
@@ -53,7 +53,7 @@ class EntityResolveRegression(ScoringAlgorithm):
 
     NAME = "er-unstable"
     MODEL_PATH = DATA_PATH.joinpath(f"{NAME}.pkl")
-    FEATURES: list[CompareFunction] = [
+    FEATURES: ClassVar[list[CompareFunction]] = [
         name_token_overlap,
         name_numbers,
         legal_name_levenshtein,
@@ -121,7 +121,7 @@ class EntityResolveRegression(ScoringAlgorithm):
         pred = pipe.predict_proba(npfeat)
         score = float(pred[0][1])
         explanations: dict[str, FtResult] = {}
-        for feature, coeff in zip(cls.FEATURES, encoded):
+        for feature, coeff in zip(cls.FEATURES, encoded, strict=True):
             name = feature.__name__
             explanations[name] = FtResult(score=float(coeff), detail=None)
         return MatchingResult(score=score, explanations=explanations)

--- a/nomenklatura/matching/erun/train.py
+++ b/nomenklatura/matching/erun/train.py
@@ -19,10 +19,10 @@ from followthemoney import EntityProxy
 from followthemoney.exc import InvalidData
 from followthemoney.util import PathLike
 from numpy.typing import NDArray
-from sklearn import metrics  # type: ignore
-from sklearn.linear_model import LogisticRegressionCV  # type: ignore
-from sklearn.pipeline import Pipeline  # type: ignore
-from sklearn.preprocessing import StandardScaler  # type: ignore
+from sklearn import metrics  # type: ignore[import-untyped]
+from sklearn.linear_model import LogisticRegressionCV  # type: ignore[import-untyped]
+from sklearn.pipeline import Pipeline  # type: ignore[import-untyped]
+from sklearn.preprocessing import StandardScaler  # type: ignore[import-untyped]
 
 from nomenklatura.judgement import Judgement
 from nomenklatura.matching.erun.model import EntityResolveRegression
@@ -386,7 +386,7 @@ def fit_model(
     coefficients = {
         feature.__name__: float(coefficient)
         for feature, coefficient in zip(
-            EntityResolveRegression.FEATURES, classifier.coef_[0]
+            EntityResolveRegression.FEATURES, classifier.coef_[0], strict=True
         )
     }
     report = {

--- a/nomenklatura/matching/logic_v1/model.py
+++ b/nomenklatura/matching/logic_v1/model.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from nomenklatura.matching.compare.addresses import address_entity_match
 from nomenklatura.matching.compare.countries import country_mismatch
 from nomenklatura.matching.compare.dates import dob_day_disjoint, dob_year_disjoint
@@ -41,7 +43,7 @@ class LogicV1(HeuristicAlgorithm):
     recommended for new integrations."""
 
     NAME = "logic-v1"
-    features = [
+    features: ClassVar[list[Feature]] = [
         Feature(func=name_literal_match, weight=1.0),
         Feature(func=person_name_jaro_winkler, weight=0.8),
         Feature(func=person_name_phonetic_match, weight=0.9),

--- a/nomenklatura/matching/logic_v2/model.py
+++ b/nomenklatura/matching/logic_v2/model.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from nomenklatura.matching.compare.addresses import (
     address_entity_match,
     address_prop_match,
@@ -39,7 +41,7 @@ class LogicV2(HeuristicAlgorithm):
     """
 
     NAME = "logic-v2"
-    features = [
+    features: ClassVar[list[Feature]] = [
         Feature(func=name_match, weight=1.0),
         Feature(func=address_entity_match, weight=0.98),
         Feature(func=crypto_wallet_address, weight=0.98),
@@ -59,7 +61,7 @@ class LogicV2(HeuristicAlgorithm):
         Feature(func=dob_day_disjoint, weight=-0.25, qualifier=True),
         Feature(func=gender_mismatch, weight=-0.2, qualifier=True),
     ]
-    CONFIG = {
+    CONFIG: ClassVar[dict[str, ConfigVar]] = {
         "nm_name_property": ConfigVar(
             type=ConfigVarType.STRING,
             description="The property to use for name matching. If not set, all name properties are used.",

--- a/nomenklatura/matching/logic_v2/names/util.py
+++ b/nomenklatura/matching/logic_v2/names/util.py
@@ -12,7 +12,7 @@ def part_tags_compatible(query: Name, result: Name) -> bool:
     name against the given name. Such pairs must fall through to the
     full alignment machinery, which penalises the role swap, instead of
     short-circuiting to a 1.0 literal match."""
-    for qp, rp in zip(query.parts, result.parts):
+    for qp, rp in zip(query.parts, result.parts, strict=False):
         if not qp.tag.can_match(rp.tag):
             return False
     return True

--- a/nomenklatura/matching/name_based/model.py
+++ b/nomenklatura/matching/name_based/model.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from nomenklatura.matching.compare.countries import country_mismatch
 from nomenklatura.matching.compare.gender import gender_mismatch
 from nomenklatura.matching.name_based.misc import (
@@ -22,7 +24,7 @@ class OFACMatcher(HeuristicAlgorithm):
     actually triage matches via FAQ 5."""
 
     NAME = "ofac"
-    features = [
+    features: ClassVar[list[Feature]] = [
         Feature(func=ofac_name_score, weight=1.0),
         Feature(func=country_mismatch, weight=-0.1, qualifier=True),
         Feature(func=dob_year_disjoint, weight=-0.1, qualifier=True),
@@ -48,7 +50,7 @@ class NameMatcher(HeuristicAlgorithm):
     based on FAQ #249, but does not reach OFAC parity."""
 
     NAME = "name-based"
-    features = [
+    features: ClassVar[list[Feature]] = [
         Feature(func=jaro_name_parts, weight=0.5),
         Feature(func=soundex_name_parts, weight=0.5),
     ]
@@ -71,7 +73,7 @@ class NameQualifiedMatcher(HeuristicAlgorithm):
     tax/registration identifiers are included for organizations and companies."""
 
     NAME = "name-qualified"
-    features = [
+    features: ClassVar[list[Feature]] = [
         Feature(func=jaro_name_parts, weight=0.5),
         Feature(func=soundex_name_parts, weight=0.5),
         Feature(func=country_mismatch, weight=-0.1, qualifier=True),

--- a/nomenklatura/matching/name_based/ofac.py
+++ b/nomenklatura/matching/name_based/ofac.py
@@ -78,7 +78,7 @@ def _simmetrics_jw(left: str, right: str) -> float:
         return 0.0
     prefix_matches = 0
     for left_char, right_char in zip(
-        left[:WINKLER_PREFIX_MAX], right[:WINKLER_PREFIX_MAX]
+        left[:WINKLER_PREFIX_MAX], right[:WINKLER_PREFIX_MAX], strict=False
     ):
         if left_char == right_char:
             prefix_matches += 1

--- a/nomenklatura/matching/regression_v1/model.py
+++ b/nomenklatura/matching/regression_v1/model.py
@@ -1,10 +1,10 @@
 import pickle
 from functools import cache
-from typing import cast
+from typing import ClassVar, cast
 
 import numpy as np
 from followthemoney.proxy import E
-from sklearn.pipeline import Pipeline  # type: ignore
+from sklearn.pipeline import Pipeline  # type: ignore[import-untyped]
 
 from nomenklatura.matching.compare.dates import (
     dob_matches,
@@ -49,7 +49,7 @@ class RegressionV1(ScoringAlgorithm):
 
     NAME = "regression-v1"
     MODEL_PATH = DATA_PATH.joinpath(f"{NAME}.pkl")
-    FEATURES: list[CompareFunction] = [
+    FEATURES: ClassVar[list[CompareFunction]] = [
         name_match,
         name_token_overlap,
         name_numbers,
@@ -114,7 +114,7 @@ class RegressionV1(ScoringAlgorithm):
         pred = pipe.predict_proba(npfeat)
         score = float(pred[0][1])
         explanations: dict[str, FtResult] = {}
-        for feature, coeff in zip(cls.FEATURES, encoded):
+        for feature, coeff in zip(cls.FEATURES, encoded, strict=True):
             name = feature.__name__
             explanations[name] = FtResult(score=float(coeff), detail=None)
         return MatchingResult(score=score, explanations=explanations)

--- a/nomenklatura/matching/regression_v1/train.py
+++ b/nomenklatura/matching/regression_v1/train.py
@@ -7,11 +7,11 @@ from pprint import pprint
 import numpy as np
 from followthemoney.util import PathLike
 from numpy.typing import NDArray
-from sklearn import metrics  # type: ignore
-from sklearn.linear_model import LogisticRegression  # type: ignore
-from sklearn.model_selection import train_test_split  # type: ignore
-from sklearn.pipeline import make_pipeline  # type: ignore
-from sklearn.preprocessing import StandardScaler  # type: ignore
+from sklearn import metrics  # type: ignore[import-untyped]
+from sklearn.linear_model import LogisticRegression  # type: ignore[import-untyped]
+from sklearn.model_selection import train_test_split  # type: ignore[import-untyped]
+from sklearn.pipeline import make_pipeline  # type: ignore[import-untyped]
+from sklearn.preprocessing import StandardScaler  # type: ignore[import-untyped]
 
 from nomenklatura.judgement import Judgement
 from nomenklatura.matching.pairs import JudgedPair, read_pairs
@@ -71,7 +71,9 @@ def train_matcher(pairs_file: PathLike) -> None:
     pipe = make_pipeline(StandardScaler(), logreg)
     pipe.fit(X_train, y_train)
     coef = logreg.coef_[0]
-    coefficients = {n.__name__: c for n, c in zip(RegressionV1.FEATURES, coef)}
+    coefficients = {
+        n.__name__: c for n, c in zip(RegressionV1.FEATURES, coef, strict=True)
+    }
     RegressionV1.save(pipe, coefficients)
     print("Written to: %s" % RegressionV1.MODEL_PATH.as_posix())
     print("Coefficients:")

--- a/nomenklatura/matching/types.py
+++ b/nomenklatura/matching/types.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from enum import Enum
-from typing import cast
+from typing import ClassVar, cast
 
 from followthemoney import E, EntityProxy
 from pydantic import BaseModel
@@ -180,7 +180,7 @@ class ScoringAlgorithm:
     """An implementation of a scoring system that compares two entities."""
 
     NAME = "algorithm_name"
-    CONFIG: dict[str, ConfigVar] = {}
+    CONFIG: ClassVar[dict[str, ConfigVar]] = {}
 
     @classmethod
     def compare(cls, query: E, result: E, config: ScoringConfig) -> MatchingResult:
@@ -236,12 +236,12 @@ class Feature:
         if self.func.__code__.co_argcount == 3:
             func = cast("FeatureCompareConfigured", self.func)
             return func(query, result, config)
-        func = cast("FeatureCompareFunction", self.func)  # type: ignore
-        return func(query, result)  # type: ignore
+        func = cast("FeatureCompareFunction", self.func)  # type: ignore[assignment]
+        return func(query, result)  # type: ignore[call-arg]
 
 
 class HeuristicAlgorithm(ScoringAlgorithm):
-    features: list[Feature]
+    features: ClassVar[list[Feature]]
 
     @classmethod
     def compute_score(

--- a/nomenklatura/store/base.py
+++ b/nomenklatura/store/base.py
@@ -140,7 +140,7 @@ class View(Generic[DS, SE]):
                 yield prop, adjacent
 
     def entities(
-        self, include_schemata: list[Schema] = []
+        self, include_schemata: list[Schema] | None = None
     ) -> Generator[SE, None, None]:
         """Iterate over all entities in the view.
 

--- a/nomenklatura/store/level.py
+++ b/nomenklatura/store/level.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 
 import orjson
-import plyvel  # type: ignore
+import plyvel  # type: ignore[import-untyped]
 from followthemoney import DS, SE, Property, Schema, Statement, model, registry
 from followthemoney.exc import InvalidData
 from followthemoney.statement.util import get_prop_type

--- a/nomenklatura/store/redis_.py
+++ b/nomenklatura/store/redis_.py
@@ -74,7 +74,7 @@ class RedisWriter(Writer[DS, SE]):
         datasets: set[str] = set()
         keys = (f"s:{entity_id}", f"x:{entity_id}")
         for v in self.store.db.sunion(keys):
-            stmt = unpack_statement(v, entity_id, False)  # type: ignore
+            stmt = unpack_statement(v, entity_id, False)  # type: ignore[arg-type]
             statements.append(stmt)
             datasets.add(stmt.dataset)
 
@@ -107,7 +107,7 @@ class RedisView(View[DS, SE]):
         if self.external:
             keys.append(b(f"x:{id}"))
         for v in self.store.db.sunion(keys):
-            statements.append(unpack_statement(v, id, False))  # type: ignore
+            statements.append(unpack_statement(v, id, False))  # type: ignore[arg-type]
         return self.store.assemble(statements)
 
     def get_inverted(self, id: str) -> Generator[tuple[Property, SE], None, None]:

--- a/nomenklatura/store/versioned.py
+++ b/nomenklatura/store/versioned.py
@@ -90,7 +90,7 @@ class VersionedRedisStore(Store[DS, SE]):
         )
 
     def view(
-        self, scope: DS, external: bool = False, versions: dict[str, str] = {}
+        self, scope: DS, external: bool = False, versions: dict[str, str] | None = None
     ) -> "VersionedRedisView[DS, SE]":
         return VersionedRedisView(self, scope, external=external, versions=versions)
 
@@ -238,9 +238,10 @@ class VersionedRedisView(View[DS, SE]):
         store: VersionedRedisStore[DS, SE],
         scope: DS,
         external: bool = False,
-        versions: dict[str, str] = {},
+        versions: dict[str, str] | None = None,
     ) -> None:
         super().__init__(store, scope, external=external)
+        versions = versions or {}
         self.store: VersionedRedisStore[DS, SE] = store
 
         # Get the latest version for each dataset in the scope

--- a/nomenklatura/tui/dedupe.py
+++ b/nomenklatura/tui/dedupe.py
@@ -1,10 +1,11 @@
 import asyncio
-from typing import Generic, cast
+from typing import ClassVar, Generic, cast
 
 from followthemoney import DS, SE, Dataset, StatementEntity
 from rich.console import RenderableType
 from rich.text import Text
 from textual.app import App, ComposeResult
+from textual.binding import BindingType
 from textual.containers import Grid, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widget import Widget
@@ -142,7 +143,7 @@ class ConfirmEditModal(ModalScreen[bool]):
 
 
 class HistoryListView(ListView):
-    BINDINGS = [
+    BINDINGS: ClassVar[list[BindingType]] = [
         ("x", "positive", "Match"),
         ("n", "negative", "No match"),
         ("u", "unsure", "Unsure"),
@@ -237,7 +238,7 @@ class DedupeApp(App[int], Generic[DS, SE]):
     CSS_PATH = "dedupe.tcss"
     dedupe: DedupeState[DS, SE]
 
-    BINDINGS = [
+    BINDINGS: ClassVar[list[BindingType]] = [
         ("x", "positive", "Match"),
         ("n", "negative", "No match"),
         ("u", "unsure", "Unsure"),

--- a/nomenklatura/tui/reconcile.py
+++ b/nomenklatura/tui/reconcile.py
@@ -1,9 +1,10 @@
-from typing import Generic, cast
+from typing import ClassVar, Generic, cast
 
 from followthemoney import DS, SE, Dataset, StatementEntity, registry
 from rich.console import RenderableType
 from rich.text import Text
 from textual.app import App, ComposeResult
+from textual.binding import BindingType
 from textual.containers import VerticalScroll
 from textual.widget import Widget
 from textual.widgets import DataTable, Footer
@@ -211,9 +212,9 @@ class ReconcileApp(App[int], Generic[DS, SE]):
     CSS_PATH = "reconcile.tcss"
     reconcile: ReconcileState[DS, SE]
     # Maps table rows to candidate indexes; informational rows map to None.
-    _row_highlights: list[int | None] = []
+    _row_highlights: list[int | None]
 
-    BINDINGS = [
+    BINDINGS: ClassVar[list[BindingType]] = [
         ("x", "confirm", "Confirm"),
         ("n", "negative", "No match"),
         ("u", "unsure", "Unsure"),

--- a/nomenklatura/wikidata/util.py
+++ b/nomenklatura/wikidata/util.py
@@ -52,7 +52,7 @@ def make_session(
     """
     session = Session()
     session.headers["User-Agent"] = user_agent
-    session.request = partial(session.request, timeout=timeout)  # type: ignore
+    session.request = partial(session.request, timeout=timeout)  # type: ignore[method-assign]
     retries = Retry(
         total=total_retries,
         backoff_factor=backoff_factor,

--- a/nomenklatura/xref.py
+++ b/nomenklatura/xref.py
@@ -42,7 +42,7 @@ def xref(
     range: Schema | None = None,
     auto_threshold: float | None = None,
     min_threshold: float = 0.01,
-    focus_datasets: set[str] = set(),
+    focus_datasets: set[str] | None = None,
     algorithm: type[ScoringAlgorithm] = DedupeAlgorithm,
     heuristic: Callable[[Resolver[SE], SE, SE, float], float | None] | None = None,
     config: ScoringConfig | None = None,
@@ -105,7 +105,7 @@ def xref(
             if not left.schema.can_match(right.schema):
                 continue
 
-            if len(focus_datasets) > 0:
+            if focus_datasets:
                 if left.datasets.isdisjoint(
                     focus_datasets
                 ) and right.datasets.isdisjoint(focus_datasets):


### PR DESCRIPTION
> Stacked on #354 — base it against `main` once that merges.

The four bug-prone rules from the ruff sweep that are worth fixing by hand, all in `nomenklatura/`. 43 sites, no autofixes used.

## RUF012 — mutable class defaults (14)

Feature lists, matcher `CONFIG` dicts, `Index.BOOSTS` and the Textual `BINDINGS` are all genuine class-level config, so they get `ClassVar`. That's also what Textual's own `DOMNode` declares (`BINDINGS: ClassVar[list[BindingType]]`), so the annotations now line up with the base class instead of just satisfying the linter. `ScoringAlgorithm.CONFIG` and `HeuristicAlgorithm.features` are annotated in the base too, otherwise mypy rejects a `ClassVar` override of an instance variable.

The one that isn't a `ClassVar`: `ReconcileApp._row_highlights` is per-instance state. `refresh_candidates()` rebinds it with `self._row_highlights = []` before anything reads it, so the class-level `[]` was dead rather than shared — it's now a bare annotation with no default.

## B006 — mutable argument defaults (5)

None of the five were actually mutated, so this is defensive. One is more than that though: `View.entities()` declared `include_schemata: list[Schema] = []` while all five concrete stores already override it as `list[Schema] | None = None`. The ABC now matches its own implementations.

## B905 — `zip()` without `strict=` (6)

Split by intent rather than blanket-applied:

- `strict=True` (4) — the feature/coefficient pairings in both regression models and both trainers. `encode_pair` is a comprehension over `FEATURES` and the training matrix is built with `len(FEATURES)` columns, so the lengths are structurally equal; if they ever diverge, the current code silently misattributes coefficients to the wrong features and the explanations in `MatchingResult` are quietly wrong. Worth failing loudly.
- `strict=False` (2) — `zip(query.parts, result.parts)` in the name-tag guard and the Jaro-Winkler prefix loop in the OFAC matcher both compare strings of different length on purpose.

## PGH003 — blanket `# type: ignore` (18)

Each narrowed to the code mypy actually reports, so they stop masking unrelated errors that appear on the same line later. Found by stripping the ignores and reading mypy's output; every site mapped to exactly one code.

Eleven are `import-untyped` for sklearn and plyvel. Those could alternatively be collapsed into a `[[tool.mypy.overrides]]` block with `ignore_missing_imports`, which would be less repetitive — say the word and I'll switch. Worth noting mypy's `enable_error_code = ["ignore-without-code"]` would keep this rule enforced on the mypy side.

## Verification

- `mypy --strict nomenklatura/` — clean, 107 files
- `pytest tests/` — 331 passed
- Import smoke test on both TUI apps, the blocker index and all three matchers, since the test suite doesn't exercise the Textual code

🤖 Generated with [Claude Code](https://claude.com/claude-code)