### PR TITLE
Configure ruff lint rules in pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,10 +6,11 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.13.0
+  rev: v0.16.0
   hooks:
     - id: ruff-check
-      args: ['--select', 'I', '--fix']
+      # Rule selection lives in pyproject.toml, not here.
+      args: ['--fix']
     - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.15.0

--- a/nomenklatura/cache.py
+++ b/nomenklatura/cache.py
@@ -5,7 +5,7 @@ from collections.abc import Generator
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from random import randint
-from typing import Any, Union, cast
+from typing import Any, cast
 
 from followthemoney import Dataset
 from rigour.time import naive_now
@@ -17,7 +17,7 @@ from sqlalchemy.sql.expression import delete
 from nomenklatura.db import Session
 
 log = logging.getLogger(__name__)
-Value = Union[str, None]
+Value = str | None
 
 
 @dataclass

--- a/nomenklatura/db.py
+++ b/nomenklatura/db.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import Generator, Iterable, Mapping
 from contextlib import contextmanager
 from functools import cache
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 from followthemoney import Statement
 from sqlalchemy import (
@@ -25,7 +25,7 @@ from sqlalchemy.sql.expression import Executable
 from nomenklatura import settings
 
 Conn = Connection
-Connish = Optional[Connection]
+Connish = Connection | None
 KEY_LEN = 255
 VALUE_LEN = 65535
 # Max rows per INSERT for SQLite to stay under SQLITE_MAX_VARIABLE_NUMBER (32,766).

--- a/nomenklatura/matching/compare/util.py
+++ b/nomenklatura/matching/compare/util.py
@@ -1,8 +1,7 @@
 import re
 from collections.abc import Callable, Iterable
-from typing import Optional
 
-CleanFunc = Optional[Callable[[str], str | None]]
+CleanFunc = Callable[[str], str | None] | None
 FIND_NUM = re.compile(r"\d{1,}")
 
 

--- a/nomenklatura/store/__init__.py
+++ b/nomenklatura/store/__init__.py
@@ -1,9 +1,7 @@
 from pathlib import Path
-from typing import Optional
 
 import orjson
 from followthemoney import Dataset, StatementEntity
-from followthemoney.dataset import DataCatalog
 from normality import slugify
 
 from nomenklatura.resolver import Resolver

--- a/nomenklatura/util.py
+++ b/nomenklatura/util.py
@@ -2,12 +2,12 @@ import os
 import re
 from collections.abc import Iterable, Mapping
 from pathlib import Path
-from typing import Optional, TypeVar
+from typing import TypeVar
 
 T = TypeVar("T")
 DATA_PATH = Path(os.path.join(os.path.dirname(__file__), "data")).resolve()
 ID_CLEAN = re.compile(r"[^A-Z0-9]+", re.UNICODE)
-HeadersType = Optional[Mapping[str, str | bytes | None]]
+HeadersType = Mapping[str, str | bytes | None] | None
 
 
 def unroll(values: Iterable[Iterable[T]]) -> list[T]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,45 @@ only-include = ["nomenklatura", "LICENSE", "README.md"]
 [tool.distutils.bdist_wheel]
 universal = true
 
+[tool.ruff.lint]
+# Rule families below are clean across nomenklatura/, tests/ and contrib/, so
+# the hook fails on a regression rather than on pre-existing debt. Individual
+# codes are pinned where the wider family still has open findings; run
+# `ruff check --select ALL --statistics` to see what is left on the table.
+select = [
+    "ASYNC", # flake8-async
+    "E4",    # pycodestyle: imports (E501 line length is left to the formatter)
+    "E7",
+    "E9",
+    "F",     # pyflakes
+    "FURB",  # refurb
+    "I",     # isort
+    "ICN",   # flake8-import-conventions
+    "INT",   # flake8-gettext
+    "LOG",   # flake8-logging
+    "PIE",   # flake8-pie
+    "Q",     # flake8-quotes
+    "RSE",   # flake8-raise
+    "SLOT",  # flake8-slots
+    "W",     # pycodestyle warnings
+    "YTT",   # flake8-2020
+    "B006",  # mutable argument default
+    "B905",  # zip() without explicit strict=
+    "PGH003", # blanket type: ignore
+    "RUF012", # mutable class default without ClassVar
+    "RUF022", # unsorted __all__
+    "RUF023", # unsorted __slots__
+    "TC006",  # unquoted cast() type
+    "UP004",  # useless object inheritance
+    "UP006",  # PEP 585 generics
+    "UP007",  # PEP 604 unions
+    "UP012",  # unnecessary encode("utf-8")
+    "UP015",  # redundant open() mode
+    "UP017",  # datetime.UTC
+    "UP035",  # deprecated typing imports
+    "UP045",  # PEP 604 optionals
+]
+
 [tool.coverage.run]
 branch = true
 

--- a/tests/enrich/test_common.py
+++ b/tests/enrich/test_common.py
@@ -5,8 +5,8 @@ from nomenklatura.enrich.common import BaseEnricher
 dataset = Dataset.make({"name": "test", "title": "Test"})
 
 
-def make_entity(schema: str, topics: list = []) -> StatementEntity:
-    properties = {"name": ["Thing"], "topics": topics}
+def make_entity(schema: str, topics: list[str] | None = None) -> StatementEntity:
+    properties = {"name": ["Thing"], "topics": topics or []}
     data = {"schema": schema, "id": "xxx", "properties": properties}
     return StatementEntity.from_data(dataset, data)
 


### PR DESCRIPTION
> Stacked on #356, which is stacked on #354. Rebase down to `main` as those merge.

The pre-commit hook hardcoded `--select I`, so isort was the only rule we ever enforced — and because the selection lived in hook args rather than config, an editor running `ruff check` or a bare CLI invocation disagreed with what CI actually checked. This moves selection into `[tool.ruff.lint]` and reduces the hook to `--fix`.

## What's selected

Whole families that are **already clean** across `nomenklatura/`, `tests/` and `contrib/`, so the hook fails on a regression rather than on pre-existing debt:

`ASYNC`, `E4`/`E7`/`E9`, `F`, `FURB`, `I`, `ICN`, `INT`, `LOG`, `PIE`, `Q`, `RSE`, `SLOT`, `W`, `YTT`

Plus individual codes pinned where the wider family still has open findings — everything the two preceding PRs cleared, so it can't come back: `B006`, `B905`, `PGH003`, `RUF012`, `RUF022`, `RUF023`, `TC006`, and the pyupgrade set `UP004`/`UP006`/`UP007`/`UP012`/`UP015`/`UP017`/`UP035`/`UP045`.

`E501` is deliberately absent — line length is the formatter's job, and 84 sites exceed it.

## Five fixes needed to get there

- Four type aliases ruff only rewrites under `--unsafe-fixes`, because a bare `X | None` assignment is a runtime expression rather than an annotation. Fine on `requires-python >= 3.11`: `Value`, `Connish`, `CleanFunc`, `HeadersType`.
- `tests/enrich/test_common.py` had `topics: list = []` as a mutable default.
- Two genuinely unused imports in `nomenklatura/store/__init__.py` (`Optional`, `DataCatalog`) — neither is in `__all__`, so they weren't re-exports.

Also bumps `ruff-pre-commit` v0.13.0 → v0.16.0 to match the CLI these sweeps were run with.

## What's left unselected

`ruff check --select ALL --statistics` still shows plenty. The notable ones and why they're out:

- `S` (1,248) — almost entirely `S101` assert-in-tests. Wants a `per-file-ignores` decision first.
- `PL` (350) — mostly `PLR2004` magic values and the `too-many-*` complexity rules.
- `FBT` (109) — boolean-trap style; would require changing public signatures.
- `UP031` (46) + `G002` (16) — printf-style logging. This is the batch I'd suggest doing next; `G002`/`G004` are latent correctness issues, since `log.info("%s" % x)` formats eagerly and defeats structured logging.
- `ANN` (420) — 259 of those are missing `-> None` in `tests/`, which mypy doesn't check today.

## Verification

- `ruff check .` — clean under the new config
- `mypy --strict nomenklatura/` — clean, 107 files
- `pytest tests/` — 331 passed

## Not addressed

`ruff format --check` still reports 4 tracked test files with pre-existing drift (`tests/matching/erun/test_misc.py`, `tests/matching/name_based/test_ofac.py`, `tests/test_positions.py`, `tests/test_wikidata_propose.py`). None are touched by this stack — the format hook only runs on staged files, so they've quietly drifted. Happy to sweep them separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)