### PR TITLE
Skip xref pairs where both candidates are external

### DIFF
--- a/nomenklatura/tui/comparison.py
+++ b/nomenklatura/tui/comparison.py
@@ -9,6 +9,20 @@ from nomenklatura.tui.util import comparison_props
 
 
 def render_column(entity: Entity) -> Text:
+    """Render the header of one candidate's column in a comparison table.
+
+    An entity backed only by external statements is an unverified enrichment
+    suggestion rather than published data, which changes what a reviewer is
+    actually deciding, so it is marked with a trailing asterisk and a distinct
+    colour for the schema label.
+    """
+    if entity.external:
+        return Text.assemble(
+            (entity.schema.label, "yellow"),
+            " [%s] " % entity.id,
+            ("*", "yellow bold"),
+            no_wrap=True,
+        )
     return Text.assemble(
         (entity.schema.label, "blue"), " [%s]" % entity.id, no_wrap=True
     )

--- a/nomenklatura/xref.py
+++ b/nomenklatura/xref.py
@@ -115,6 +115,11 @@ def xref(
                 if not left.schema.is_a(range) and not right.schema.is_a(range):
                     continue
 
+            # Two pre-verification suggestions have nothing to anchor to each other;
+            # xref should spend its budget expanding the graph instead.
+            if left.external and right.external:
+                continue
+
             if scored:
                 score = algorithm.compare(left, right, config).score
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 requires-python = ">= 3.11"
 dependencies = [
-    "followthemoney >= 4.8.1, < 5.0.0",
+    "followthemoney >= 4.10.2, < 5.0.0",
     "rigour >= 2.2.3, < 3.0.0",
     "fingerprints >= 1.3.1, < 2.0.0",
     "shortuuid >= 1.0.11, < 2.0.0",

--- a/tests/test_tui_comparison.py
+++ b/tests/test_tui_comparison.py
@@ -1,0 +1,21 @@
+from followthemoney import Dataset, StatementEntity
+
+from nomenklatura.tui.comparison import render_column
+
+
+def test_render_column_marks_external_entities() -> None:
+    """A candidate that is only an unverified suggestion must be visibly
+    distinct from published data in the comparison header."""
+    dataset = Dataset.make({"name": "comparison"})
+    internal = StatementEntity(dataset, {"id": "int-1", "schema": "Person"})
+    internal.add("name", "Vladimir Vladimirovich Putin")
+    external = StatementEntity(dataset, {"id": "ext-1", "schema": "Person"})
+    external.add("name", "Vladimir Vladimirovich Putin", external=True)
+
+    internal_column = render_column(internal)
+    assert internal_column.plain == "Person [int-1]"
+    assert [s.style for s in internal_column.spans] == ["blue"]
+
+    external_column = render_column(external)
+    assert external_column.plain == "Person [ext-1] *"
+    assert [s.style for s in external_column.spans] == ["yellow", "yellow bold"]

--- a/tests/test_xref.py
+++ b/tests/test_xref.py
@@ -1,11 +1,11 @@
 import json
 from pathlib import Path
 
-from followthemoney import StatementEntity
+from followthemoney import Dataset, StatementEntity
 
 from nomenklatura.judgement import Judgement
 from nomenklatura.resolver import Resolver
-from nomenklatura.store import SimpleMemoryStore, load_entity_file_store
+from nomenklatura.store import MemoryStore, SimpleMemoryStore, load_entity_file_store
 from nomenklatura.xref import xref
 
 
@@ -96,3 +96,28 @@ def test_xref_patience_ignores_decided_pairs(
         candidate_ids.update((left_id, right_id))
     assert "dupe-1" in candidate_ids
     assert "dupe-2" in candidate_ids
+
+
+def test_xref_skips_external_pairs(
+    index_path: Path,
+    resolver: Resolver[StatementEntity],
+    db_session,
+):
+    """Two entities that are made up entirely of external statements must not be
+    suggested against each other, but each must still be compared to real data."""
+    dataset = Dataset.make({"name": "external_pairs"})
+    store = MemoryStore(dataset, resolver)
+    with store.writer() as writer:
+        entities = (("ext-1", True), ("ext-2", True), ("int-1", False))
+        for entity_id, external in entities:
+            entity = StatementEntity(dataset, {"id": entity_id, "schema": "Company"})
+            entity.add("name", "Zeta Petrochemical Holding", external=external)
+            entity.add("country", "de", external=external)
+            writer.add_entity(entity)
+
+    xref(resolver, db_session, store, index_path)
+
+    pairs = {frozenset((left, right)) for left, right, _ in resolver.get_candidates()}
+    assert frozenset(("ext-1", "ext-2")) not in pairs
+    assert frozenset(("int-1", "ext-1")) in pairs
+    assert frozenset(("int-1", "ext-2")) in pairs


### PR DESCRIPTION
An entity backed only by external statements is an enrichment suggestion that has not been through verification. Comparing two of them cannot anchor anything into the graph, so the pair is worth neither a scoring run nor a slot in the review queue — xref should spend its budget expanding outward from real data instead.

The check sits in the pair loop rather than in `Resolver.get_judgement` (where the QID/QID rule lives) because externality is transient state: the same pair becomes worth scoring as soon as either side is verified, and a recorded judgement would outlive that.

Requires the entity-level `external` aggregate from followthemoney 4.10.2, so the dependency floor moves up accordingly.

Note that the skip does not recover pair budget — `max_pairs` is applied by the blocker's SQL `LIMIT`, so external/external pairs still occupy slots in the ranking, they just stop costing an `algorithm.compare()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)