### PR TITLE
Filter external statements in SQLView reads

### DIFF
--- a/nomenklatura/store/base.py
+++ b/nomenklatura/store/base.py
@@ -109,7 +109,12 @@ class View(Generic[DS, SE]):
 
     Entities come back in their merged, canonical form. Use `get_entity()` for
     a lookup by ID, `entities()` to stream the whole scope, and `get_adjacent()`
-    to traverse relationships in both directions."""
+    to traverse relationships in both directions.
+
+    Statements marked `external` (enrichment candidates not yet accepted into
+    the dataset) are excluded from all reads unless the view is constructed
+    with `external=True`; an entity backed only by external statements is
+    absent from an `external=False` view."""
 
     def __init__(self, store: Store[DS, SE], scope: DS, external: bool = False):
         self.store = store

--- a/nomenklatura/store/sql.py
+++ b/nomenklatura/store/sql.py
@@ -200,6 +200,8 @@ class SQLView(View[DS, SE]):
         q = select(table)
         q = q.where(table.c.canonical_id == id)
         q = q.where(table.c.dataset.in_(self.dataset_names))
+        if self.external is False:
+            q = q.where(table.c.external.is_(False))
         for proxy in self.store._iterate(q, stream=False):
             return proxy
         return None
@@ -209,6 +211,8 @@ class SQLView(View[DS, SE]):
         q = select(func.count(table.c.id))
         q = q.where(table.c.canonical_id == id)
         q = q.where(table.c.dataset.in_(self.dataset_names))
+        if self.external is False:
+            q = q.where(table.c.external.is_(False))
         with self.store.engine.connect() as conn:
             cursor = conn.execute(q)
             count = cursor.scalar()
@@ -224,6 +228,8 @@ class SQLView(View[DS, SE]):
         q = q.where(table.c.prop_type == "entity")
         q = q.where(table.c.value.in_(ids))
         q = q.where(table.c.dataset.in_(self.dataset_names))
+        if self.external is False:
+            q = q.where(table.c.external.is_(False))
         q = q.group_by(table.c.canonical_id)
         with self.store.engine.connect() as conn:
             cursor = conn.execute(q)
@@ -244,6 +250,8 @@ class SQLView(View[DS, SE]):
         table: Table = self.store.table
         q = select(table)
         q = q.where(table.c.dataset.in_(self.dataset_names))
+        if self.external is False:
+            q = q.where(table.c.external.is_(False))
         q = q.order_by(table.c.canonical_id)
         for entity in self.store._iterate(q, stream=True):
             if include_schemata is not None and entity.schema not in include_schemata:

--- a/tests/store/test_stores.py
+++ b/tests/store/test_stores.py
@@ -71,6 +71,33 @@ def _run_store_test(
     entity = view.get_entity(entity.id)
     assert entity is not None
     assert entity.caption == "Tchibo Holding AG"
+
+    # External statements must be filtered by external=False views and
+    # survive a store round-trip with the flag intact:
+    ext_data = {
+        "id": "ext-john-doe",
+        "schema": "Person",
+        "properties": {"name": ["John Doe"]},
+    }
+    ext_entity = Entity.from_data(dataset, ext_data)
+    with store.writer() as writer:
+        for stmt in ext_entity.statements:
+            writer.add_statement(stmt.clone(external=True))
+
+    internal_view = store.view(dataset, external=False)
+    assert internal_view.get_entity("ext-john-doe") is None
+    assert not internal_view.has_entity("ext-john-doe")
+    assert "ext-john-doe" not in {e.id for e in internal_view.entities()}
+
+    ext_view = store.view(dataset, external=True)
+    served = ext_view.get_entity("ext-john-doe")
+    assert served is not None
+    assert ext_view.has_entity("ext-john-doe")
+    served_stmts = list(served.statements)
+    assert len(served_stmts) == len(list(ext_entity.statements))
+    # The synthetic `id` statement is regenerated on read; the flag only
+    # needs to survive on the stored property statements.
+    assert all(s.external for s in served_stmts if s.prop != "id")
     return True
 
 


### PR DESCRIPTION
Closes #355.

The SQL half of the issue: `SQLView` accepted `external: bool = False` but never added a `table.c.external` predicate, so SQL-backed views always behaved as `external=True` — enrichment-candidate statements leaked into views callers asked to be published-only.

- All four `SQLView` query paths (`get_entity`, `has_entity`, `get_inverted`, `entities`) now bind `external IS false` when the view is constructed with `external=False`, matching the per-statement semantics of the memory and LevelDB stores.
- The expected semantics are now stated on the base `View` docstring, per the issue's suggestion.
- The shared `_run_store_test` (SQL, memory, LevelDB) gains an external round-trip check: an all-external entity is invisible to an `external=False` view and served with flags intact by an `external=True` view. It fails on the SQL store without the fix.

The Redis half of the issue is resolved by #359 removing those backends entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)