### PR TITLE
feat: statement-store and resolver fixes + mnemo learning artifacts

### DIFF
--- a/nomenklatura/db.py
+++ b/nomenklatura/db.py
@@ -212,6 +212,10 @@ def make_statement_table(
         Column("external", Boolean, default=False, nullable=False),
         Column("first_seen", DateTime, nullable=True),
         Column("last_seen", DateTime, nullable=True),
+        # The metadata object is a process-wide cache (get_metadata), so a
+        # second store in one process re-declares the table; keep the first
+        # definition instead of raising.
+        keep_existing=True,
     )
 
 

--- a/nomenklatura/resolver/resolver.py
+++ b/nomenklatura/resolver/resolver.py
@@ -180,6 +180,14 @@ class Resolver(Linker[SE]):
         """
         self._load_all()
 
+    def commit(self) -> None:
+        """Commit pending judgement writes on this resolver's session.
+
+        Writers (suggest/decide/load_edges callers) own the transaction
+        boundary; this saves them reaching into the private session.
+        """
+        self._session.commit()
+
     def get_linker(self) -> Linker[SE]:
         """Return a linker object that can be used to resolve entities.
         This is less memory-consuming than the full resolver object.

--- a/nomenklatura/store/sql.py
+++ b/nomenklatura/store/sql.py
@@ -69,17 +69,20 @@ class SQLStore(Store[DS, SE]):
     def _iterate(
         self, q: Select[Any], stream: bool = True
     ) -> Generator[SE, None, None]:
+        # Group by canonical_id, not entity_id: queries and scopes operate on
+        # canonical ids, and a merged entity's rows span several entity_ids.
+        # Grouping on entity_id would fragment every merged cluster.
         current_id = None
         current_stmts: list[Statement] = []
         for stmt in self._iterate_stmts(q, stream=stream):
-            entity_id = stmt.entity_id
+            canonical_id = stmt.canonical_id
             if current_id is None:
-                current_id = entity_id
-            if current_id != entity_id:
+                current_id = canonical_id
+            if current_id != canonical_id:
                 proxy = self.assemble(current_stmts)
                 if proxy is not None:
                     yield proxy
-                current_id = entity_id
+                current_id = canonical_id
                 current_stmts = []
             current_stmts.append(stmt)
         if current_stmts:


### PR DESCRIPTION
- store/sql.py: SQLView external filter; _iterate groups by canonical_id (merged entities assembled whole, not fragmented per referent)
- db.py: make_statement_table keep_existing (process-wide MetaData cache)
- resolver.py: public Resolver.commit()
- lessons/, mnemo-model/, notes: archive of the throth design exploration